### PR TITLE
【タスク新規作成・編集画面】本番環境でタグ選択ボタンを押した際に、タグ選択ボックスが表示されないバグの修正

### DIFF
--- a/app/views/tasks/edit.html.erb
+++ b/app/views/tasks/edit.html.erb
@@ -26,21 +26,22 @@
           <%= f.label :tag_ids, class: "label text-custom-dark-green font-medium" %>
           <!-- タグ選択ドロップダウン -->
           <div class="dropdown">
-            <!-- ♻️safariブラウザ含むすべてのブラウザで動作するコード。https://v4.daisyui.com/components/dropdown/#method-2-using-css-focus
-            <div tabindex="0" role="button" class="btn btn-outline">
+            <!-- ♻️safariブラウザ含むすべてのブラウザで動作するコード。https://v4.daisyui.com/components/dropdown/#method-2-using-css-focus -->
+            <div tabindex="0" role="button" class="btn btn-outline w-full bg-custom-white border-custom-dark-green text-custom-dark-green hover:bg-custom-dark-green hover:text-custom-white">
               <span>選択</span>
               <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 16 16" fill="currentColor" class="size-4">
                 <path fill-rule="evenodd" d="M4.22 6.22a.75.75 0 0 1 1.06 0L8 8.94l2.72-2.72a.75.75 0 1 1 1.06 1.06l-3.25 3.25a.75.75 0 0 1-1.06 0L4.22 7.28a.75.75 0 0 1 0-1.06Z" clip-rule="evenodd" />
               </svg>
             </div>
-            -->
+
             <!-- ⚠️buttonタグを使用した場合、safariブラウザでは動作しない可能性がある。https://v4.daisyui.com/components/dropdown/#method-2-using-css-focus-->
-            <button type="button" class="btn btn-outline w-full bg-custom-white border-custom-dark-green text-custom-dark-green hover:bg-custom-dark-green hover:text-white">
+            <!-- <button type="button" class="btn btn-outline w-full bg-custom-white border-custom-dark-green text-custom-dark-green hover:bg-custom-dark-green hover:text-white">
               <span>選択</span>
               <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 16 16" fill="currentColor" class="size-4">
                 <path fill-rule="evenodd" d="M4.22 6.22a.75.75 0 0 1 1.06 0L8 8.94l2.72-2.72a.75.75 0 1 1 1.06 1.06l-3.25 3.25a.75.75 0 0 1-1.06 0L4.22 7.28a.75.75 0 0 1 0-1.06Z" clip-rule="evenodd" />
               </svg>
             </button>
+            -->
 
             <!-- 🎓tabindex="0"により、ラベルをクリックしても画面が閉じなくなる。-->
             <ul tabindex="0" class="dropdown-content bg-custom-white rounded-box z-[1] p-2 shadow w-full max-h-60 overflow-y-auto border border-custom-light-gray/50">

--- a/app/views/tasks/new.html.erb
+++ b/app/views/tasks/new.html.erb
@@ -26,21 +26,22 @@
           <%= f.label :tag_ids, class: "label text-custom-dark-green font-medium" %>
           <!-- タグ選択ドロップダウン -->
           <div class="dropdown">
-            <!-- ♻️safariブラウザ含むすべてのブラウザで動作するコード。https://v4.daisyui.com/components/dropdown/#method-2-using-css-focus
-            <div tabindex="0" role="button" class="btn btn-outline">
+            <!-- ♻️safariブラウザ含むすべてのブラウザで動作するコード。https://v4.daisyui.com/components/dropdown/#method-2-using-css-focus -->
+            <div tabindex="0" role="button" class="btn btn-outline w-full bg-custom-white border-custom-dark-green text-custom-dark-green hover:bg-custom-dark-green hover:text-custom-white">
               <span>選択</span>
               <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 16 16" fill="currentColor" class="size-4">
                 <path fill-rule="evenodd" d="M4.22 6.22a.75.75 0 0 1 1.06 0L8 8.94l2.72-2.72a.75.75 0 1 1 1.06 1.06l-3.25 3.25a.75.75 0 0 1-1.06 0L4.22 7.28a.75.75 0 0 1 0-1.06Z" clip-rule="evenodd" />
               </svg>
             </div>
-            -->
+            
             <!-- ⚠️buttonタグを使用した場合、safariブラウザでは動作しない可能性がある。https://v4.daisyui.com/components/dropdown/#method-2-using-css-focus-->
-            <button type="button" class="btn btn-outline w-full bg-custom-white border-custom-dark-green text-custom-dark-green hover:bg-custom-dark-green hover:text-white">
+            <!-- <button type="button" class="btn btn-outline w-full bg-custom-white border-custom-dark-green text-custom-dark-green hover:bg-custom-dark-green hover:text-white">
               <span>選択</span>
               <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 16 16" fill="currentColor" class="size-4">
                 <path fill-rule="evenodd" d="M4.22 6.22a.75.75 0 0 1 1.06 0L8 8.94l2.72-2.72a.75.75 0 1 1 1.06 1.06l-3.25 3.25a.75.75 0 0 1-1.06 0L4.22 7.28a.75.75 0 0 1 0-1.06Z" clip-rule="evenodd" />
               </svg>
             </button>
+            -->
 
             <!-- 🎓tabindex="0"により、ラベルをクリックしても画面が閉じなくなる。-->
             <ul tabindex="0" class="dropdown-content bg-custom-white rounded-box z-[1] p-2 shadow w-full max-h-60 overflow-y-auto border border-custom-light-gray/50">


### PR DESCRIPTION
## 概要
本番環境において、タスク新規作成・編集画面でのタグ選択ボタンをクリックした際に、タグ選択ボックスが表示されないバグを修正した。
### 関連するissue
- #106 

## 実装
https://v4.daisyui.com/components/dropdown/#method-2-using-css-focus
> We can't use `<button>` here because Safari has [a bug](https://bugs.webkit.org/show_bug.cgi?id=22261) that prevents the button from being focused.
`<div role="button" tabindex="0">` is a workaround for this bug.
It is accessible and works in all browsers.
- `<button>`タグによる実装を削除し、`<div role="button" tabindex="0">`タグによる実装に修正

### タスク新規作成画面
#### 修正前
```ruby
# app/views/tasks/new.html.erb
<!-- ⚠️buttonタグを使用した場合、safariブラウザでは動作しない可能性がある。https://v4.daisyui.com/components/dropdown/#method-2-using-css-focus-->
<button type="button" class="btn btn-outline w-full bg-custom-white border-custom-dark-green text-custom-dark-green hover:bg-custom-dark-green hover:text-white">
  <span>選択</span>
  <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 16 16" fill="currentColor" class="size-4">
    <path fill-rule="evenodd" d="M4.22 6.22a.75.75 0 0 1 1.06 0L8 8.94l2.72-2.72a.75.75 0 1 1 1.06 1.06l-3.25 3.25a.75.75 0 0 1-1.06 0L4.22 7.28a.75.75 0 0 1 0-1.06Z" clip-rule="evenodd" />
  </svg>
</button>
```

#### 修正後
```ruby
# app/views/tasks/new.html.erb
<!-- ♻️safariブラウザ含むすべてのブラウザで動作するコード。https://v4.daisyui.com/components/dropdown/#method-2-using-css-focus -->
<div tabindex="0" role="button" class="btn btn-outline w-full bg-custom-white border-custom-dark-green text-custom-dark-green hover:bg-custom-dark-green hover:text-custom-white">
  <span>選択</span>
  <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 16 16" fill="currentColor" class="size-4">
    <path fill-rule="evenodd" d="M4.22 6.22a.75.75 0 0 1 1.06 0L8 8.94l2.72-2.72a.75.75 0 1 1 1.06 1.06l-3.25 3.25a.75.75 0 0 1-1.06 0L4.22 7.28a.75.75 0 0 1 0-1.06Z" clip-rule="evenodd" />
  </svg>
</div>
```

