### PR TITLE
fix: Renderデプロイ時に、seedデータを投入するように設定を変更 🔧

### DIFF
--- a/bin/render-build.sh
+++ b/bin/render-build.sh
@@ -4,3 +4,4 @@ bundle install
 bundle exec rails assets:precompile
 bundle exec rails assets:clean
 bundle exec rails db:migrate
+bundle exec rails db:seed


### PR DESCRIPTION
## 概要
Renderデプロイ時に、seedデータを投入するように設定を変更した。

## 実装
```
# bin/render-build.sh
set -o errexit

bundle install
bundle exec rails assets:precompile
bundle exec rails assets:clean
bundle exec rails db:migrate
bundle exec rails db:seed # この記述を追加
```