### PR TITLE
refactor: タグに関するデバッグ情報の表示を削除 🔥

### DIFF
--- a/app/views/tasks/edit.html.erb
+++ b/app/views/tasks/edit.html.erb
@@ -44,11 +44,6 @@
             -->
 
             <!-- 🎓tabindex="0"により、ラベルをクリックしても画面が閉じなくなる。-->
-            <!-- デバッグ情報（本番環境でも表示） -->
-            <div class="p-2 bg-red-100 text-xs text-red-800 border-b">
-              デバッグ: タグ数 <%= Tag.count %>個 | 
-              タグ一覧: <%= Tag.all.map(&:name).join(', ') %>
-            </div>
             <ul tabindex="0" class="dropdown-content bg-custom-white rounded-box z-[1] p-2 shadow w-full max-h-60 overflow-y-auto border border-custom-light-gray/50">
               <% Tag.all.each do |tag| %>
                 <li class="rounded p-1">

--- a/app/views/tasks/new.html.erb
+++ b/app/views/tasks/new.html.erb
@@ -44,11 +44,6 @@
             -->
 
             <!-- 🎓tabindex="0"により、ラベルをクリックしても画面が閉じなくなる。-->
-            <!-- デバッグ情報（本番環境でも表示） -->
-            <div class="p-2 bg-red-100 text-xs text-red-800 border-b">
-              デバッグ: タグ数 <%= Tag.count %>個 | 
-              タグ一覧: <%= Tag.all.map(&:name).join(', ') %>
-            </div>
             <ul tabindex="0" class="dropdown-content bg-custom-white rounded-box z-[1] p-2 shadow w-full max-h-60 overflow-y-auto border border-custom-light-gray/50">
               <% Tag.all.each do |tag| %>
                 <li class="rounded p-1">


### PR DESCRIPTION
## 概要
本番環境でタグ選択ボックスのタグ一覧が表示されない問題について、根本原因は`bin/render-build.sh`においてseedデータを投入していないため、本番環境でTagデータが存在しないことだった。
問題が解決したためタグに関するデバッグ情報の表示を削除した。

### 関連するissue
- #106 