### PR TITLE
【認証画面】エラーメッセージの日本語対応

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -7,4 +7,5 @@ class User < ApplicationRecord
   has_many :posts, dependent: :destroy
   # カスタムバリデーション
   validates :name, presence: true, length: { minimum: 2, maximum: 50 }
+  validates :password, presence: true, length: { minimum: 6 }
 end

--- a/app/views/users/sessions/new.html.erb
+++ b/app/views/users/sessions/new.html.erb
@@ -20,6 +20,23 @@
       </div>
       
       <%= form_for(resource, as: resource_name, url: session_path(resource_name), html: { class: "flex flex-col gap-5 w-full" }) do |f| %>
+        <%= render "users/shared/error_messages", resource: resource %>
+        
+        <% if flash[:alert] %>
+          <div class="alert bg-custom-white border border-custom-rust text-custom-rust mb-4">
+            <div class="flex flex-col gap-2">
+              <div class="flex items-center gap-2">
+                <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="2.0" stroke="currentColor" class="size-5">
+                  <path stroke-linecap="round" stroke-linejoin="round" d="M12 9v3.75m-9.303 3.376c-.866 1.5.217 3.374 1.948 3.374h14.71c1.73 0 2.813-1.874 1.948-3.374L13.949 3.378c-.866-1.5-3.032-1.5-3.898 0L2.697 16.126ZM12 15.75h.007v.008H12v-.008Z" />
+                </svg>
+                <h3 class="font-bold text-custom-brown">ログインエラー</h3>
+              </div>
+              <div class="text-sm text-custom-brown">
+                <%= flash[:alert] %>
+              </div>
+            </div>
+          </div>
+        <% end %>
         <div class="field w-full">
           <%= f.label :email, class: "text-custom-dark-green font-medium" %><br />
           <%= f.email_field :email, autofocus: true, autocomplete: "email", placeholder: "id@gmail.com", class: "input input-bordered w-full bg-custom-white border-custom-dark-green text-custom-dark-green focus:border-custom-dark-green focus:ring-2 focus:ring-custom-dark-green/20 focus:outline-none placeholder:text-custom-dark-green/50" %>

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -15,7 +15,14 @@ ja:
 
   # ActiveRecordの属性名翻訳
   activerecord:
+    models:
+      user: "ユーザー"
     attributes:
+      user:
+        name: "名前"
+        email: "メールアドレス"
+        password: "パスワード"
+        password_confirmation: "パスワード（確認）"
       task:
         title: "タイトル"
         tag_ids: "タグ"
@@ -24,9 +31,35 @@ ja:
   # エラーメッセージの和訳
   errors:
     messages:
+      not_saved: "%{count}件のエラーにより、%{resource}を保存できませんでした"
       blank: "を入力してください"
       too_short: "は%{count}文字以上で入力してください"
       too_long: "は%{count}文字以下で入力してください"
     attributes:
       tag_ids:
         too_many: "は最大5個まで選択できます"
+
+  # Deviseのエラーメッセージの和訳
+  devise:
+    failure:
+      user:
+        invalid: "メールアドレスまたはパスワードが違います"
+        not_found_in_database: "メールアドレスまたはパスワードが違います"
+        locked: "アカウントがロックされています"
+        unconfirmed: "メールアドレスの本人確認が必要です"
+        unauthenticated: "ログインしてください"
+      invalid: "メールアドレスまたはパスワードが違います"
+      not_found_in_database: "メールアドレスまたはパスワードが違います"
+      locked: "アカウントがロックされています"
+      unconfirmed: "メールアドレスの本人確認が必要です"
+      unauthenticated: "ログインしてください"
+    sessions:
+      user:
+        signed_in: "ログインしました"
+        signed_out: "ログアウトしました"
+        already_signed_out: "ログアウトしました"
+    registrations:
+      user:
+        signed_up: "アカウント登録が完了しました"
+        updated: "アカウント情報を変更しました"
+        destroyed: "アカウントを削除しました"


### PR DESCRIPTION
## 概要
- ログイン画面にフラッシュメッセージを追加し、認証に失敗した場合エラーメッセージが表示されるように修正
- 認証画面のエラーメッセージを日本語対応

### 関連するissue
- #120

## 実装
### ログイン画面にフラッシュメッセージを追加
```ruby
# app/views/users/sessions/new.html.erb
        <% if flash[:alert] %>
          <div class="alert bg-custom-white border border-custom-rust text-custom-rust mb-4">
            <div class="flex flex-col gap-2">
              <div class="flex items-center gap-2">
                <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="2.0" stroke="currentColor" class="size-5">
                  <path stroke-linecap="round" stroke-linejoin="round" d="M12 9v3.75m-9.303 3.376c-.866 1.5.217 3.374 1.948 3.374h14.71c1.73 0 2.813-1.874 1.948-3.374L13.949 3.378c-.866-1.5-3.032-1.5-3.898 0L2.697 16.126ZM12 15.75h.007v.008H12v-.008Z" />
                </svg>
                <h3 class="font-bold text-custom-brown">ログインエラー</h3>
              </div>
              <div class="text-sm text-custom-brown">
                <%= flash[:alert] %>
              </div>
            </div>
          </div>
```

### i18nの設定ファイルを変更し日本語対応
```yaml
# config/locales/ja.yml
  # ActiveRecordの属性名翻訳
  activerecord:
    models:
      user: "ユーザー"
    attributes:
      user:
        name: "名前"
        email: "メールアドレス"
        password: "パスワード"
        password_confirmation: "パスワード（確認）"
.
.
.

  # エラーメッセージの和訳
  errors:
    messages:
      not_saved: "%{count}件のエラーにより、%{resource}を保存できませんでした"
.
.
.

  # Deviseのエラーメッセージの和訳
  devise:
    failure:
      user:
        invalid: "メールアドレスまたはパスワードが違います"
        not_found_in_database: "メールアドレスまたはパスワードが違います"
        locked: "アカウントがロックされています"
        unconfirmed: "メールアドレスの本人確認が必要です"
        unauthenticated: "ログインしてください"
      invalid: "メールアドレスまたはパスワードが違います"
      not_found_in_database: "メールアドレスまたはパスワードが違います"
      locked: "アカウントがロックされています"
      unconfirmed: "メールアドレスの本人確認が必要です"
      unauthenticated: "ログインしてください"
    sessions:
      user:
        signed_in: "ログインしました"
        signed_out: "ログアウトしました"
        already_signed_out: "ログアウトしました"
    registrations:
      user:
        signed_up: "アカウント登録が完了しました"
        updated: "アカウント情報を変更しました"
        destroyed: "アカウントを削除しました"
```

### Userモデルのpasswordカラムに文字数の下限を設定
```ruby
# app/models/user.rb
class User < ApplicationRecord
.
.
.
  validates :password, presence: true, length: { minimum: 6 }
end
```

### ログイン画面

<img width="300" alt="Image" src="https://github.com/user-attachments/assets/8df38271-d556-4d1a-8506-69e042dfd91e" />

### 新規登録画面

<img width="300" alt="Image" src="https://github.com/user-attachments/assets/d0c9ddd7-59f1-4e77-a19e-704a84882f7c" />