### PR TITLE
Userモデルのカスタムバリデーションを修正し、Userモデルスペックにバリデーションテストを追加

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -7,5 +7,5 @@ class User < ApplicationRecord
   has_many :posts, dependent: :destroy
   # カスタムバリデーション
   validates :name, presence: true, length: { minimum: 2, maximum: 20 }
-  validates :password, presence: true, length: { minimum: 6 }
+  validates :password, presence: true, length: { minimum: 8 }
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -6,6 +6,6 @@ class User < ApplicationRecord
   has_many :tasks, dependent: :destroy
   has_many :posts, dependent: :destroy
   # カスタムバリデーション
-  validates :name, presence: true, length: { minimum: 2, maximum: 50 }
+  validates :name, presence: true, length: { minimum: 2, maximum: 20 }
   validates :password, presence: true, length: { minimum: 6 }
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -7,5 +7,4 @@ class User < ApplicationRecord
   has_many :posts, dependent: :destroy
   # カスタムバリデーション
   validates :name, presence: true, length: { minimum: 2, maximum: 20 }
-  validates :password, presence: true, length: { minimum: 8 }
 end

--- a/config/initializers/devise.rb
+++ b/config/initializers/devise.rb
@@ -178,7 +178,7 @@ Devise.setup do |config|
 
   # ==> Configuration for :validatable
   # Range for password length.
-  config.password_length = 6..128
+  config.password_length = 8..128
 
   # Email regex used to validate email formats. It simply asserts that
   # one (and only one) @ exists in the given string. This is mainly

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -1,29 +1,71 @@
 require 'rails_helper'
 
 RSpec.describe User, type: :model do
-  describe 'バリデーションチェック' do
-    it '設定したすべてのバリデーションが機能しているか' do
-      user = build(:user)
-      expect(user).to be_valid
-      expect(user.errors).to be_empty
+  describe 'バリデーション' do
+    let(:user) { build(:user) }
+
+    describe 'name' do
+      context '存在性' do
+        it 'nameが存在する場合は有効' do
+          user.name = 'userテスト'
+          expect(user).to be_valid
+        end
+
+        it 'nameが空の場合は無効' do
+          user.name = ''
+          expect(user).not_to be_valid
+          expect(user.errors[:name]).to include('を入力してください')
+        end
+
+        it 'nameがnilの場合は無効' do
+          user.name = nil
+          expect(user).not_to be_valid
+          expect(user.errors[:name]).to include('を入力してください')
+        end
+      end
+
+      context '文字数制限' do
+        it '2文字以上20文字以内の場合は有効' do
+          user.name = 'テスト'
+          expect(user).to be_valid
+        end
+
+        it '1文字の場合は無効' do
+          user.name = 'A'
+          expect(user).not_to be_valid
+          expect(user.errors[:name]).to include('は2文字以上で入力してください')
+        end
+
+        it '21文字以上の場合は無効' do
+          user.name = 'A' * 21
+          expect(user).not_to be_valid
+          expect(user.errors[:name]).to include('は20文字以下で入力してください')
+        end
+      end
     end
 
-    it 'nameがない場合、バリデーションが機能し、invalidになる' do
-      user = build(:user, name: nil)
-      expect(user).to be_invalid
-      expect(user.errors[:name]).to include("can't be blank")
-    end
+    describe 'password' do
+      context '文字数制限' do
+        it '8文字以上128文字以内の場合は有効' do
+          user.password = '12345678'
+          user.password_confirmation = '12345678'
+          expect(user).to be_valid
+        end
 
-    it 'nameが1文字の場合、バリデーションが機能し、invalidになる' do
-      user = build(:user, name: 'A')
-      expect(user).to be_invalid
-      expect(user.errors[:name]).to include('is too short (minimum is 2 characters)')
-    end
+        it '7文字以下の場合は無効' do
+          user.password = '1234567'
+          user.password_confirmation = '1234567'
+          expect(user).not_to be_valid
+          expect(user.errors[:password]).to include('は8文字以上で入力してください')
+        end
 
-    it 'nameが51文字の場合、バリデーションが機能し、invalidになる' do
-      user = build(:user, name: 'A' * 51)
-      expect(user).to be_invalid
-      expect(user.errors[:name]).to include('is too long (maximum is 50 characters)')
+        it '129文字以上の場合は無効' do
+          user.password = 'a' * 129
+          user.password_confirmation = 'a' * 129
+          expect(user).not_to be_valid
+          expect(user.errors[:password]).to include('は128文字以下で入力してください')
+        end
+      end
     end
   end
 end


### PR DESCRIPTION
## 概要
Userモデルのnameカラムとpasswordカラムのバリデーションを修正

## 実装
### Userモデルのカスタムバリデーションを修正
- nameカラムは2~20文字
- passwordは8~128文字（こちらは後述するイニシャライザで設定）
```ruby
# app/models/user.rb
  validates :name, presence: true, length: { minimum: 2, maximum: 20 }
```

### 新規登録画面に表示されるパスワードの最低文字数を修正
- イニシャライザでパスワードの最低文字数を8文字に変更
```ruby
# config/initializers/devise.rb
  config.password_length = 8..128
```

#### 変更後の新規登録画面

<img width="300" alt="Image" src="https://github.com/user-attachments/assets/3faa3f39-5bba-40f1-9660-9d34ef95ae2e" />

### Userモデルスペックのバリデーションテストの修正
```ruby
# spec/models/user_spec.rb
require 'rails_helper'

RSpec.describe User, type: :model do
  describe 'バリデーション' do
    let(:user) { build(:user) }

    describe 'name' do
      context '存在性' do
        it 'nameが存在する場合は有効' do
          user.name = 'userテスト'
          expect(user).to be_valid
        end

        it 'nameが空の場合は無効' do
          user.name = ''
          expect(user).not_to be_valid
          expect(user.errors[:name]).to include('を入力してください')
        end

        it 'nameがnilの場合は無効' do
          user.name = nil
          expect(user).not_to be_valid
          expect(user.errors[:name]).to include('を入力してください')
        end
      end

      context '文字数制限' do
        it '2文字以上20文字以内の場合は有効' do
          user.name = 'テスト'
          expect(user).to be_valid
        end

        it '1文字の場合は無効' do
          user.name = 'A'
          expect(user).not_to be_valid
          expect(user.errors[:name]).to include('は2文字以上で入力してください')
        end

        it '21文字以上の場合は無効' do
          user.name = 'A' * 21
          expect(user).not_to be_valid
          expect(user.errors[:name]).to include('は20文字以下で入力してください')
        end
      end
    end

    describe 'password' do
      context '文字数制限' do
        it '8文字以上128文字以内の場合は有効' do
          user.password = '12345678'
          user.password_confirmation = '12345678'
          expect(user).to be_valid
        end

        it '7文字以下の場合は無効' do
          user.password = '1234567'
          user.password_confirmation = '1234567'
          expect(user).not_to be_valid
          expect(user.errors[:password]).to include('は8文字以上で入力してください')
        end

        it '129文字以上の場合は無効' do
          user.password = 'a' * 129
          user.password_confirmation = 'a' * 129
          expect(user).not_to be_valid
          expect(user.errors[:password]).to include('は128文字以下で入力してください')
        end
      end
    end
  end
end
```