### PR TITLE
 【認証画面】エラーメッセージの日本語対応を整理

### DIFF
--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -40,6 +40,8 @@ ja:
       blank: "を入力してください"
       too_short: "は%{count}文字以上で入力してください"
       too_long: "は%{count}文字以下で入力してください"
+      invalid: "は無効な値です"
+      taken: "はすでに存在しています"
     attributes:
       tag_ids:
         too_many: "は最大5個まで選択できます"

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -52,21 +52,5 @@ ja:
       user:
         invalid: "メールアドレスまたはパスワードが違います"
         not_found_in_database: "メールアドレスまたはパスワードが違います"
-        locked: "アカウントがロックされています"
-        unconfirmed: "メールアドレスの本人確認が必要です"
-        unauthenticated: "ログインしてください"
       invalid: "メールアドレスまたはパスワードが違います"
       not_found_in_database: "メールアドレスまたはパスワードが違います"
-      locked: "アカウントがロックされています"
-      unconfirmed: "メールアドレスの本人確認が必要です"
-      unauthenticated: "ログインしてください"
-    sessions:
-      user:
-        signed_in: "ログインしました"
-        signed_out: "ログアウトしました"
-        already_signed_out: "ログアウトしました"
-    registrations:
-      user:
-        signed_up: "アカウント登録が完了しました"
-        updated: "アカウント情報を変更しました"
-        destroyed: "アカウントを削除しました"

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -13,7 +13,7 @@ ja:
         tag_ids: "タグ"
         todos: "ToDoリスト"
 
-  # ActiveRecordの属性名翻訳
+  # ActiveRecordの属性名の和訳
   activerecord:
     models:
       user: "ユーザー"

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -7,7 +7,7 @@ RSpec.describe User, type: :model do
     describe 'name' do
       context '存在性' do
         it 'nameが存在する場合は有効' do
-          user.name = 'userテスト'
+          user.name = 'user_name'
           expect(user).to be_valid, 'nameが存在する場合は有効である必要があります'
         end
 
@@ -26,18 +26,18 @@ RSpec.describe User, type: :model do
 
       context '文字数制限' do
         it '2文字以上20文字以内の場合は有効' do
-          user.name = 'テスト'
+          user.name = 'user_name'
           expect(user).to be_valid, 'nameが2文字以上20文字以内の場合は有効である必要があります'
         end
 
         it '1文字の場合は無効' do
-          user.name = 'A'
+          user.name = 'a'
           expect(user).not_to be_valid, 'nameが1文字の場合は無効である必要があります'
           expect(user.errors[:name]).to include('は2文字以上で入力してください')
         end
 
         it '21文字以上の場合は無効' do
-          user.name = 'A' * 21
+          user.name = 'a' * 21
           expect(user).not_to be_valid, 'nameが21文字以上の場合は無効である必要があります'
           expect(user.errors[:name]).to include('は20文字以下で入力してください')
         end
@@ -47,14 +47,14 @@ RSpec.describe User, type: :model do
     describe 'password' do
       context '文字数制限' do
         it '8文字以上128文字以内の場合は有効' do
-          user.password = '12345678'
-          user.password_confirmation = '12345678'
+          user.password = 'a' * 8
+          user.password_confirmation = 'a' * 8
           expect(user).to be_valid, 'passwordが8文字以上128文字以内の場合は有効である必要があります'
         end
 
         it '7文字以下の場合は無効' do
-          user.password = '1234567'
-          user.password_confirmation = '1234567'
+          user.password = 'a' * 7
+          user.password_confirmation = 'a' * 7
           expect(user).not_to be_valid, 'passwordが7文字以下の場合は無効である必要があります'
           expect(user.errors[:password]).to include('は8文字以上で入力してください')
         end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -84,15 +84,45 @@ RSpec.describe User, type: :model do
       end
 
       context '形式' do
-        it '有効なemail形式の場合は有効' do
-          user.email = 'test@example.com'
-          expect(user).to be_valid
+        context '有効なemail形式' do
+          let(:valid_emails) do
+            [
+              'user@example.com',
+              'user.name@example.com',
+              'user+name@example.com',
+              'user@example-domain.com',
+              'user@example.co.jp',
+              'user123@example.com'
+            ]
+          end
+
+          it '有効なemail形式の場合は有効' do
+            valid_emails.each do |email|
+              user.email = email
+              expect(user).to be_valid, "#{email}は有効なemail形式である必要があります"
+            end
+          end
         end
 
-        it '無効なemail形式の場合は無効' do
-          user.email = 'invalid-email'
-          expect(user).not_to be_valid
-          expect(user.errors[:email]).to include('は無効な値です')
+        context '無効なemail形式' do
+          let(:invalid_emails) do
+            [
+              'user',
+              '@example.com',
+              'user@',
+              'user @example.com',
+              'user@@example.com',
+              'user@example .com'
+            ]
+          end
+
+          it '無効なemail形式の場合は無効' do
+            invalid_emails.each do |email|
+              user.email = email
+              expect(user).not_to be_valid, "#{email}は無効なemail形式である必要があります"
+              expect(user.errors[:email]).to include('は無効な値です')
+            end
+          end
         end
       end
 

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -13,13 +13,13 @@ RSpec.describe User, type: :model do
 
         it 'nameが空の場合は無効' do
           user.name = ''
-          expect(user).not_to be_valid
+          expect(user).not_to be_valid, 'nameが空の場合は無効である必要があります'
           expect(user.errors[:name]).to include('を入力してください')
         end
 
         it 'nameがnilの場合は無効' do
           user.name = nil
-          expect(user).not_to be_valid
+          expect(user).not_to be_valid, 'nameがnilの場合は無効である必要があります'
           expect(user.errors[:name]).to include('を入力してください')
         end
       end
@@ -32,13 +32,13 @@ RSpec.describe User, type: :model do
 
         it '1文字の場合は無効' do
           user.name = 'A'
-          expect(user).not_to be_valid
+          expect(user).not_to be_valid, 'nameが1文字の場合は無効である必要があります'
           expect(user.errors[:name]).to include('は2文字以上で入力してください')
         end
 
         it '21文字以上の場合は無効' do
           user.name = 'A' * 21
-          expect(user).not_to be_valid
+          expect(user).not_to be_valid, 'nameが21文字以上の場合は無効である必要があります'
           expect(user.errors[:name]).to include('は20文字以下で入力してください')
         end
       end
@@ -55,14 +55,14 @@ RSpec.describe User, type: :model do
         it '7文字以下の場合は無効' do
           user.password = '1234567'
           user.password_confirmation = '1234567'
-          expect(user).not_to be_valid
+          expect(user).not_to be_valid, 'passwordが7文字以下の場合は無効である必要があります'
           expect(user.errors[:password]).to include('は8文字以上で入力してください')
         end
 
         it '129文字以上の場合は無効' do
           user.password = 'a' * 129
           user.password_confirmation = 'a' * 129
-          expect(user).not_to be_valid
+          expect(user).not_to be_valid, 'passwordが129文字以上の場合は無効である必要があります'
           expect(user.errors[:password]).to include('は128文字以下で入力してください')
         end
       end
@@ -72,13 +72,13 @@ RSpec.describe User, type: :model do
       context '存在性' do
         it 'emailが空の場合は無効' do
           user.email = ''
-          expect(user).not_to be_valid
+          expect(user).not_to be_valid, 'emailが空の場合は無効である必要があります'
           expect(user.errors[:email]).to include('を入力してください')
         end
 
         it 'emailがnilの場合は無効' do
           user.email = nil
-          expect(user).not_to be_valid
+          expect(user).not_to be_valid, 'emailがnilの場合は無効である必要があります'
           expect(user.errors[:email]).to include('を入力してください')
         end
       end
@@ -131,7 +131,7 @@ RSpec.describe User, type: :model do
 
         it '同じemailでユーザーを作成できない' do
           new_user = build(:user, email: 'test@example.com')
-          expect(new_user).not_to be_valid
+          expect(new_user).not_to be_valid, '同じemailでユーザーを作成できない必要があります'
           expect(new_user.errors[:email]).to include('はすでに存在しています')
         end
       end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -8,7 +8,7 @@ RSpec.describe User, type: :model do
       context '存在性' do
         it 'nameが存在する場合は有効' do
           user.name = 'userテスト'
-          expect(user).to be_valid
+          expect(user).to be_valid, 'nameが存在する場合は有効である必要があります'
         end
 
         it 'nameが空の場合は無効' do
@@ -27,7 +27,7 @@ RSpec.describe User, type: :model do
       context '文字数制限' do
         it '2文字以上20文字以内の場合は有効' do
           user.name = 'テスト'
-          expect(user).to be_valid
+          expect(user).to be_valid, 'nameが2文字以上20文字以内の場合は有効である必要があります'
         end
 
         it '1文字の場合は無効' do
@@ -49,7 +49,7 @@ RSpec.describe User, type: :model do
         it '8文字以上128文字以内の場合は有効' do
           user.password = '12345678'
           user.password_confirmation = '12345678'
-          expect(user).to be_valid
+          expect(user).to be_valid, 'passwordが8文字以上128文字以内の場合は有効である必要があります'
         end
 
         it '7文字以下の場合は無効' do
@@ -145,11 +145,11 @@ RSpec.describe User, type: :model do
       let!(:tasks) { create_list(:task, task_count, user: user) }
 
       it 'tasksにアクセスできる' do
-        expect(user.tasks).to match_array(tasks)
+        expect(user.tasks).to match_array(tasks), 'user.tasksにアクセスできる必要があります'
       end
 
       it 'userが削除されると、関連するtasksも削除される' do
-        expect { user.destroy }.to change(Task, :count).by(-task_count)
+        expect { user.destroy }.to change(Task, :count).by(-task_count), 'userが削除されると、関連するtasksも削除される必要があります'
       end
     end
 
@@ -159,11 +159,11 @@ RSpec.describe User, type: :model do
       let!(:posts) { create_list(:post, post_count, user: user) }
 
       it 'postsにアクセスできる' do
-        expect(user.posts).to match_array(posts)
+        expect(user.posts).to match_array(posts), 'user.postsにアクセスできる必要があります'
       end
 
       it 'userが削除されると、関連するpostsも削除される' do
-        expect { user.destroy }.to change(Post, :count).by(-post_count)
+        expect { user.destroy }.to change(Post, :count).by(-post_count), 'userが削除されると、関連するpostsも削除される必要があります'
       end
     end
   end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -92,7 +92,7 @@ RSpec.describe User, type: :model do
         it '無効なemail形式の場合は無効' do
           user.email = 'invalid-email'
           expect(user).not_to be_valid
-          expect(user.errors[:email]).not_to be_empty
+          expect(user.errors[:email]).to include('は無効な値です')
         end
       end
 
@@ -102,7 +102,7 @@ RSpec.describe User, type: :model do
         it '同じemailでユーザーを作成できない' do
           new_user = build(:user, email: 'test@example.com')
           expect(new_user).not_to be_valid
-          expect(new_user.errors[:email]).not_to be_empty
+          expect(new_user.errors[:email]).to include('はすでに存在しています')
         end
       end
     end


### PR DESCRIPTION
## 概要
認証画面におけるエラーメッセージの日本語対応について整理する。

### 関連するpull-request
- #121
- #173 

## 実装
### 認証画面におけるエラーメッセージの日本語対応を整理
- emailの形式と一意性に関するエラーメッセージを和訳
```yaml
# config/locales/ja.yml
  # エラーメッセージの和訳
  errors:
    messages:
      invalid: "は無効な値です"
      taken: "はすでに存在しています"
```

### Userモデルスペックのバリデーションテストを修正
####  emailの形式
```ruby
    describe 'email' do
      context '形式' do
        context '有効なemail形式' do
          let(:valid_emails) do
            [
              'user@example.com',
              'user.name@example.com',
              'user+name@example.com',
              'user@example-domain.com',
              'user@example.co.jp',
              'user123@example.com'
            ]
          end

          it '有効なemail形式の場合は有効' do
            valid_emails.each do |email|
              user.email = email
              expect(user).to be_valid, "#{email}は有効なemail形式である必要があります"
            end
          end
        end

        context '無効なemail形式' do
          let(:invalid_emails) do
            [
              'user',
              '@example.com',
              'user@',
              'user @example.com',
              'user@@example.com',
              'user@example .com'
            ]
          end

          it '無効なemail形式の場合は無効' do
            invalid_emails.each do |email|
              user.email = email
              expect(user).not_to be_valid, "#{email}は無効なemail形式である必要があります"
              expect(user.errors[:email]).to include('は無効な値です')
            end
          end
        end
      end
```

#### emailの一意性
```ruby
      context '一意性' do
        let!(:existing_user) { create(:user, email: 'test@example.com') }

        it '同じemailでユーザーを作成できない' do
          new_user = build(:user, email: 'test@example.com')
          expect(new_user).not_to be_valid, '同じemailでユーザーを作成できない必要があります'
          expect(new_user.errors[:email]).to include('はすでに存在しています')
        end
      end
```