### PR TITLE
Postモデル, TextPostモデルスペックを実装

### DIFF
--- a/app/models/text_post.rb
+++ b/app/models/text_post.rb
@@ -1,5 +1,5 @@
 class TextPost < ApplicationRecord
   include Postable
 
-  validates :body, presence: true
+  validates :body, presence: true, length: { maximum: 500 }
 end

--- a/spec/factories/posts.rb
+++ b/spec/factories/posts.rb
@@ -2,7 +2,6 @@ FactoryBot.define do
   factory :post do
     association :user
     association :task
-    postable_type { "TextPost" }
-    postable_id { create(:text_post).id }
+    association :postable
   end
 end

--- a/spec/factories/text_posts.rb
+++ b/spec/factories/text_posts.rb
@@ -1,5 +1,5 @@
 FactoryBot.define do
   factory :text_post do
-    body { "MyText" }
+    body { "text_post_body" }
   end
 end

--- a/spec/models/post_spec.rb
+++ b/spec/models/post_spec.rb
@@ -1,5 +1,64 @@
 require 'rails_helper'
 
 RSpec.describe Post, type: :model do
-  pending "add some examples to (or delete) #{__FILE__}"
+  describe 'アソシエーション' do
+    describe 'belongs_to :user' do
+      let(:user) { create(:user) }
+      let(:task) { create(:task, user: user) }
+      let(:text_post) { create(:text_post) }
+      let(:post) { build(:post, user: user, task: task, postable: text_post) }
+
+      it 'userにアクセスできる' do
+        expect(post.user).to eq user
+      end
+
+      it 'userが存在しない場合は無効' do
+        post = build(:post, user: nil, task: task, postable: text_post)
+        expect(post).not_to be_valid, 'userが存在しない場合は無効である必要があります'
+      end
+
+      it 'userが存在する場合は有効' do
+        expect(post).to be_valid, 'userが存在する場合は有効である必要があります'
+      end
+    end
+
+    describe 'belongs_to :task' do
+      let(:user) { create(:user) }
+      let(:task) { create(:task, user: user) }
+      let(:text_post) { create(:text_post) }
+      let(:post) { build(:post, user: user, task: task, postable: text_post) }
+
+      it 'taskにアクセスできる' do
+        expect(post.task).to eq task
+      end
+
+      it 'taskが存在しない場合は無効' do
+        post = build(:post, user: user, task: nil, postable: text_post)
+        expect(post).not_to be_valid, 'taskが存在しない場合は無効である必要があります'
+      end
+
+      it 'taskが存在する場合は有効' do
+        expect(post).to be_valid, 'taskが存在する場合は有効である必要があります'
+      end
+    end
+
+    describe 'delegated_type :postable' do
+      let(:user) { create(:user) }
+      let(:task) { create(:task, user: user) }
+      let(:text_post) { create(:text_post) }
+      let(:post) { create(:post, user: user, task: task, postable: text_post) }
+
+      it 'postableにアクセスできる' do
+        expect(post.postable).to eq text_post
+      end
+
+      it 'postable_typeが正しく設定される' do
+        expect(post.postable_type).to eq 'TextPost'
+      end
+
+      it 'postable_idが正しく設定される' do
+        expect(post.postable_id).to eq text_post.id
+      end
+    end
+  end
 end

--- a/spec/models/text_post_spec.rb
+++ b/spec/models/text_post_spec.rb
@@ -1,5 +1,79 @@
 require 'rails_helper'
 
 RSpec.describe TextPost, type: :model do
-  pending "add some examples to (or delete) #{__FILE__}"
+  describe 'バリデーション' do
+    let(:text_post) { build(:text_post) }
+
+    describe 'body' do
+      context '存在性' do
+        it 'bodyが存在する場合は有効' do
+          text_post.body = 'text_post_body'
+          expect(text_post).to be_valid, 'bodyが存在する場合は有効である必要があります'
+        end
+
+        it 'bodyが空の場合は無効' do
+          text_post.body = ''
+          expect(text_post).not_to be_valid, 'bodyが空の場合は無効である必要があります'
+          expect(text_post.errors[:body]).to include('を入力してください')
+        end
+
+        it 'bodyがnilの場合は無効' do
+          text_post.body = nil
+          expect(text_post).not_to be_valid, 'bodyがnilの場合は無効である必要があります'
+          expect(text_post.errors[:body]).to include('を入力してください')
+        end
+      end
+
+      context '文字数制限' do
+        it '500文字以内の場合は有効' do
+          text_post.body = 'a' * 500
+          expect(text_post).to be_valid, 'bodyが500文字以内の場合は有効である必要があります'
+        end
+
+        it '501文字以上の場合は無効' do
+          text_post.body = 'a' * 501
+          expect(text_post).not_to be_valid, 'bodyが501文字以上の場合は無効である必要があります'
+          expect(text_post.errors[:body]).to include('は500文字以下で入力してください')
+        end
+      end
+    end
+  end
+
+  describe 'アソシエーション' do
+    describe 'has_one :post' do
+      let(:text_post) { create(:text_post) }
+
+      it 'postにアクセスできる' do
+        post = create(:post, postable: text_post)
+        expect(text_post.post).to eq post
+      end
+
+      it 'text_postが削除されると、関連するpostも削除される' do
+        post = create(:post, postable: text_post)
+        expect { text_post.destroy }.to change(Post, :count).by(-1), 'text_postが削除されると、関連するpostも削除される必要があります'
+      end
+    end
+
+    describe 'has_one :task, through: :post' do
+      let(:user) { create(:user) }
+      let(:task) { create(:task, user: user) }
+      let(:text_post) { create(:text_post) }
+      let!(:post) { create(:post, user: user, task: task, postable: text_post) }
+
+      it 'taskにアクセスできる' do
+        expect(text_post.task).to eq task
+      end
+    end
+
+    describe 'has_one :user, through: :post' do
+      let(:user) { create(:user) }
+      let(:task) { create(:task, user: user) }
+      let(:text_post) { create(:text_post) }
+      let!(:post) { create(:post, user: user, task: task, postable: text_post) }
+
+      it 'userにアクセスできる' do
+        expect(text_post.user).to eq user
+      end
+    end
+  end
 end


### PR DESCRIPTION
## 概要
PostモデルとTextPostモデルのテストをRSpecで実装した。

### 関連するissue
- #127 

## 実装
### TextPostモデルに文字数制限のバリデーションを追加
```ruby
# app/models/text_post.rb
class TextPost < ApplicationRecord
  include Postable

  validates :body, presence: true, length: { maximum: 500 }
end
```

### FactoryBotの作成
#### Postsファクトリ
```ruby
# spec/factories/posts.rb

FactoryBot.define do
  factory :post do
    association :user
    association :task
    association :postable
  end
end
```

#### TextPostsファクトリ
```ruby
# spec/factories/text_posts.rb

FactoryBot.define do
  factory :text_post do
    body { "text_post_body" }
  end
end

```

### Postモデルスペックの作成
#### アソシエーションテスト


### TextPostモデルスペックの作成
#### バリデーションテスト
```ruby
# spec/models/text_post_spec.rb

  describe 'バリデーション' do
    let(:text_post) { build(:text_post) }

    describe 'body' do
      context '存在性' do
        it 'bodyが存在する場合は有効' do
          text_post.body = 'text_post_body'
          expect(text_post).to be_valid, 'bodyが存在する場合は有効である必要があります'
        end

        it 'bodyが空の場合は無効' do
          text_post.body = ''
          expect(text_post).not_to be_valid, 'bodyが空の場合は無効である必要があります'
          expect(text_post.errors[:body]).to include('を入力してください')
        end

        it 'bodyがnilの場合は無効' do
          text_post.body = nil
          expect(text_post).not_to be_valid, 'bodyがnilの場合は無効である必要があります'
          expect(text_post.errors[:body]).to include('を入力してください')
        end
      end

      context '文字数制限' do
        it '500文字以内の場合は有効' do
          text_post.body = 'a' * 500
          expect(text_post).to be_valid, 'bodyが500文字以内の場合は有効である必要があります'
        end

        it '501文字以上の場合は無効' do
          text_post.body = 'a' * 501
          expect(text_post).not_to be_valid, 'bodyが501文字以上の場合は無効である必要があります'
          expect(text_post.errors[:body]).to include('は500文字以下で入力してください')
        end
      end
    end
  end
```

#### アソシエーションテスト
```ruby
# spec/models/text_post_spec.rb

  describe 'アソシエーション' do
    describe 'has_one :post' do
      let(:text_post) { create(:text_post) }

      it 'postにアクセスできる' do
        post = create(:post, postable: text_post)
        expect(text_post.post).to eq post
      end

      it 'text_postが削除されると、関連するpostも削除される' do
        post = create(:post, postable: text_post)
        expect { text_post.destroy }.to change(Post, :count).by(-1), 'text_postが削除されると、関連するpostも削除される必要があります'
      end
    end

    describe 'has_one :task, through: :post' do
      let(:user) { create(:user) }
      let(:task) { create(:task, user: user) }
      let(:text_post) { create(:text_post) }
      let!(:post) { create(:post, user: user, task: task, postable: text_post) }

      it 'taskにアクセスできる' do
        expect(text_post.task).to eq task
      end
    end

    describe 'has_one :user, through: :post' do
      let(:user) { create(:user) }
      let(:task) { create(:task, user: user) }
      let(:text_post) { create(:text_post) }
      let!(:post) { create(:post, user: user, task: task, postable: text_post) }

      it 'userにアクセスできる' do
        expect(text_post.user).to eq user
      end
    end
  end
```