### PR TITLE
【新規登録画面】パスワードと確認用パスワードが一致しない時のエラーメッセージを日本語対応

### DIFF
--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -42,6 +42,7 @@ ja:
       too_long: "は%{count}文字以下で入力してください"
       invalid: "は無効な値です"
       taken: "はすでに登録済みです"
+      confirmation: "と%{attribute}の入力が一致しません"
     attributes:
       tag_ids:
         too_many: "は最大5個まで選択できます"

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -156,7 +156,8 @@ RSpec.describe User, type: :model do
     describe 'has_many :posts' do
       let(:user) { create(:user) }
       let(:post_count) { 2 }
-      let!(:posts) { create_list(:post, post_count, user: user) }
+      let(:text_post) { create(:text_post) }
+      let!(:posts) { create_list(:post, post_count, user: user, postable: text_post) }
 
       it 'postsにアクセスできる' do
         expect(user.posts).to match_array(posts), 'user.postsにアクセスできる必要があります'

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -68,6 +68,23 @@ RSpec.describe User, type: :model do
       end
     end
 
+    describe 'password_confirmation' do
+      context 'passwordとの一致' do
+        it 'passwordとpassword_confirmationが一致する場合は有効' do
+          user.password = 'password'
+          user.password_confirmation = 'password'
+          expect(user).to be_valid, 'passwordとpassword_confirmationが一致する場合は有効である必要があります'
+        end
+
+        it 'passwordとpassword_confirmationが一致しない場合は無効' do
+          user.password = 'password '
+          user.password_confirmation = 'different_password'
+          expect(user).not_to be_valid, 'passwordとpassword_confirmationが一致しない場合は無効である必要があります'
+          expect(user.errors[:password_confirmation]).to include('とパスワードの入力が一致しません')
+        end
+      end
+    end
+
     describe 'email' do
       context '存在性' do
         it 'emailが空の場合は無効' do

--- a/spec/system/users_spec.rb
+++ b/spec/system/users_spec.rb
@@ -92,7 +92,6 @@ RSpec.describe 'Users', type: :system do
       end
 
       it 'パスワードとパスワード確認が一致しない場合はエラーが表示される' do
-        skip 'パスワードとパスワード確認が一致しない場合はエラーが表示される'
         fill_in '名前', with: 'test_user'
         fill_in 'メールアドレス', with: 'test@example.com'
         fill_in 'パスワード', with: 'password'
@@ -100,7 +99,7 @@ RSpec.describe 'Users', type: :system do
 
         click_button '新規登録'
 
-        expect(page).to have_content('')
+        expect(page).to have_content('パスワード（確認） とパスワードの入力が一致しません')
       end
     end
   end


### PR DESCRIPTION
## 概要
- パスワードと確認用パスワードが一致しない時のエラーメッセージを日本語対応
- Userモデルスペックにて、password_confirmationのバリデーションテストを実装
- Userシステムスペックにて、'パスワードとパスワード確認が一致しない場合はエラーが表示される'のテストを実装

### 関連するissue
- #180 

## 実装
### エラーメッセージの日本語対応
```yaml
ja:

  # エラーメッセージの和訳
  errors:
    messages:
      confirmation: "と%{attribute}の入力が一致しません"
```

#### 新規登録画面でのエラーメッセージ表示

<img width="300" alt="Image" src="https://github.com/user-attachments/assets/09969768-1a66-486c-b220-c4dcad16c37e" />

### Userモデルスペックの実装
```ruby
# spec/models/user_spec.rb

    describe 'password_confirmation' do
      context 'passwordとの一致' do
        it 'passwordとpassword_confirmationが一致する場合は有効' do
          user.password = 'password'
          user.password_confirmation = 'password'
          expect(user).to be_valid, 'passwordとpassword_confirmationが一致する場合は有効である必要があります'
        end

        it 'passwordとpassword_confirmationが一致しない場合は無効' do
          user.password = 'password '
          user.password_confirmation = 'different_password'
          expect(user).not_to be_valid, 'passwordとpassword_confirmationが一致しない場合は無効である必要があります'
          expect(user.errors[:password_confirmation]).to include('とパスワードの入力が一致しません')
        end
      end
    end
```

### Userシステムスペックの実装
```ruby
# spec/system/users_spec.rb

      it 'パスワードとパスワード確認が一致しない場合はエラーが表示される' do
        fill_in '名前', with: 'test_user'
        fill_in 'メールアドレス', with: 'test@example.com'
        fill_in 'パスワード', with: 'password'
        fill_in 'パスワード（確認）', with: 'different_password'

        click_button '新規登録'

        expect(page).to have_content('パスワード（確認） とパスワードの入力が一致しません')
      end
```
