### PR TITLE
【タスク詳細画面】投稿機能のajax化

### DIFF
--- a/app/controllers/posts_controller.rb
+++ b/app/controllers/posts_controller.rb
@@ -1,26 +1,24 @@
 class PostsController < ApplicationController
   def create
     @task = current_user.tasks.find(params[:task_id])
-    @post = @task.posts.build(user: current_user)
+    
+    # ネストした属性を使用して一度に作成
+    @post = @task.posts.build(
+      user: current_user,
+      postable_type: post_params[:postable_type],
+      postable_attributes: post_params[:postable_attributes]
+    )
 
-    # TextPostを作成
-    text_post = TextPost.new(post_params)
-
-    if text_post.save
-      @post.postable = text_post
-      if @post.save
-        redirect_to @task, notice: "コメントが投稿されました。" # ♻️ renderに変更できないか？
-      else
-        redirect_to @task, alert: "投稿の保存に失敗しました。"
-      end
+    if @post.save
+      redirect_to @task, notice: "コメントが投稿されました。"
     else
-      redirect_to @task, alert: "コメントの内容が無効です。"
+      redirect_to @task, alert: "投稿の保存に失敗しました。"
     end
   end
 
   private
 
   def post_params
-    params.require(:post).require(:postable_attributes).permit(:body)
+    params.require(:post).permit(:postable_type, postable_attributes: [:body])
   end
 end

--- a/app/views/posts/_form.html.erb
+++ b/app/views/posts/_form.html.erb
@@ -1,5 +1,8 @@
 <div class="flex flex-col gap-4">
   <%= form_with model: post, url: task_posts_path(task), method: :post, local: true, class: "space-y-4", html: { id: "post_form_#{task.id}" } do |form| %>
+    <!-- postable_typeを明示的に指定 -->
+    <%= form.hidden_field :postable_type, value: "TextPost" %>
+    
     <div class="form-control">
       <%= form.fields_for :postable_attributes do |text_post_form| %>
         <%= text_post_form.text_area :body, 

--- a/app/views/posts/_form.html.erb
+++ b/app/views/posts/_form.html.erb
@@ -1,10 +1,10 @@
 <div class="flex flex-col gap-4">
-  <%= form_with model: post, url: task_posts_path(task), method: :post, local: true, class: "space-y-4", html: { id: "post_form_#{task.id}" } do |form| %>
+  <%= form_with model: post, url: task_posts_path(task), method: :post, local: true, class: "space-y-4", html: { id: "post_form_#{task.id}" } do |f| %>
     <!-- postable_typeを明示的に指定 -->
-    <%= form.hidden_field :postable_type, value: "TextPost" %>
+    <%= f.hidden_field :postable_type, value: "TextPost" %>
     
     <div class="form-control">
-      <%= form.fields_for :postable_attributes do |text_post_form| %>
+      <%= f.fields_for :postable_attributes do |text_post_form| %>
         <%= text_post_form.text_area :body, 
             placeholder: "コメントを入力してください...", 
             class: "textarea textarea-bordered w-full h-24 bg-custom-white border-custom-dark-green text-custom-dark-green focus:border-custom-dark-green focus:ring-2 focus:ring-custom-dark-green/20 focus:outline-none placeholder:text-custom-dark-green/50" %>
@@ -14,7 +14,7 @@
       そのため、form_withタグの外でボタン群を実装することで、完了ボタンを押した時、patchリクエストは正常に動作し、タスクのステータスをトグルすることができた。 -->
       <%# <div class="flex justify-end gap-4">
       <%#   <%= render "tasks/status_buttons", task: task %>
-      <%#   <%= form.submit "投稿", class: "btn bg-custom-sage hover:bg-custom-sage-dark text-custom-cream border-none" %>
+      <%#   <%= f.submit "投稿", class: "btn bg-custom-sage hover:bg-custom-sage-dark text-custom-cream border-none" %>
       <%# </div> %>
   <% end %>
 


### PR DESCRIPTION
## 概要
- postsコントローラーのリファクタリング
- タスク詳細画面の投稿機能をajax化

## 実装
### postsコントローラーのリファクタリング
- posts#createでpostとtext_post両方のレコードを一括で作成
参考記事: [Rails: ActiveRecord::DelegatedType APIドキュメント（翻訳）](https://techracho.bpsinc.jp/hachi8833/2022_04_12/112882)
```ruby
# app/controllers/posts_controller.rb
class PostsController < ApplicationController
  def create
    @task = current_user.tasks.find(params[:task_id])
    
    # ネストした属性を使用して一度に作成
    @post = @task.posts.build(
      user: current_user,
      postable_type: post_params[:postable_type],
      postable_attributes: post_params[:postable_attributes]
    )

    if @post.save
      redirect_to @task, notice: "コメントが投稿されました。"
    else
      redirect_to @task, alert: "投稿の保存に失敗しました。"
    end
  end

  private

  def post_params
    params.require(:post).permit(:postable_type, postable_attributes: [:body])
  end
end
```