### PR TITLE
【タスク詳細画面】投稿の削除機能

### DIFF
--- a/app/controllers/posts_controller.rb
+++ b/app/controllers/posts_controller.rb
@@ -25,7 +25,7 @@ class PostsController < ApplicationController
   end
 
   def destroy
-    @post.destroy!
+    @post.destroy
     
     respond_to do |format|
       format.turbo_stream

--- a/app/controllers/posts_controller.rb
+++ b/app/controllers/posts_controller.rb
@@ -1,7 +1,8 @@
 class PostsController < ApplicationController
-  def create
-    @task = current_user.tasks.find(params[:task_id])
+  before_action :set_task
+  before_action :set_post, only: [:destroy]
 
+  def create
     # ネストした属性を使用して一度に作成
     @post = @task.posts.build(
       user: current_user,
@@ -23,7 +24,24 @@ class PostsController < ApplicationController
     end
   end
 
+  def destroy
+    @post.destroy!
+    
+    respond_to do |format|
+      format.turbo_stream
+      format.html { redirect_to @task, notice: "投稿を削除しました。" }
+    end
+  end
+
   private
+
+  def set_task
+    @task = current_user.tasks.find(params[:task_id])
+  end
+
+  def set_post
+    @post = @task.posts.find(params[:id])
+  end
 
   def post_params
     params.require(:post).permit(:postable_type, postable_attributes: [ :body ])

--- a/app/javascript/controllers/index.js
+++ b/app/javascript/controllers/index.js
@@ -12,3 +12,6 @@ application.register("todo-toggle", TodoToggleController);
 
 import TodoFormController from "./todo_form_controller";
 application.register("todo-form", TodoFormController);
+
+import PostContextMenuController from "./post_context_menu_controller";
+application.register("post-context-menu", PostContextMenuController);

--- a/app/javascript/controllers/post_context_menu_controller.js
+++ b/app/javascript/controllers/post_context_menu_controller.js
@@ -71,8 +71,8 @@ export default class extends Controller {
       '[data-post-context-menu-target="menu"]:not(.hidden)'
     );
     if (openMenu) {
-      openMenu.classList.add("hidden");
-      openMenu.classList.remove("dropdown-open");
+      openMenu.classList.add(this.hiddenClass);
+      openMenu.classList.remove(this.openClass);
     }
   }
 

--- a/app/javascript/controllers/post_context_menu_controller.js
+++ b/app/javascript/controllers/post_context_menu_controller.js
@@ -4,9 +4,6 @@ export default class extends Controller {
   static targets = ["menu", "chatBubble"];
   static classes = ["hidden", "open"];
 
-  // 定数
-  MENU_OFFSET = 10;
-
   connect() {
     this.handleClickOutside = this.handleClickOutside.bind(this);
   }
@@ -34,25 +31,11 @@ export default class extends Controller {
 
   // メニューの位置を計算・設定
   positionMenu(event) {
-    const menuRect = this.menuTarget.getBoundingClientRect();
-    const viewport = { width: window.innerWidth, height: window.innerHeight };
-
-    let left = event.clientX;
-    let top = event.clientY;
-
-    // 画面端を考慮した位置調整
-    if (left + menuRect.width > viewport.width) {
-      left = viewport.width - menuRect.width - this.MENU_OFFSET;
-    }
-    if (top + menuRect.height > viewport.height) {
-      top = viewport.height - menuRect.height - this.MENU_OFFSET;
-    }
-
     // 位置を適用
     Object.assign(this.menuTarget.style, {
       position: "fixed",
-      left: `${left}px`,
-      top: `${top}px`,
+      left: `${event.clientX}px`,
+      top: `${event.clientY}px`,
       zIndex: "9999",
     });
   }

--- a/app/javascript/controllers/post_context_menu_controller.js
+++ b/app/javascript/controllers/post_context_menu_controller.js
@@ -64,16 +64,16 @@ export default class extends Controller {
     }, 0);
   }
 
-  // 他のコンテキストメニューをすべて閉じる
+  // 他のコンテキストメニューを閉じる
   hideAllMenus() {
-    document
-      .querySelectorAll(
-        '[data-controller*="post-context-menu"] [data-post-context-menu-target="menu"]'
-      )
-      .forEach((menu) => {
-        menu.classList.add("hidden");
-        menu.classList.remove("dropdown-open");
-      });
+    // 現在開いているメニューを探して閉じる
+    const openMenu = document.querySelector(
+      '[data-post-context-menu-target="menu"]:not(.hidden)'
+    );
+    if (openMenu) {
+      openMenu.classList.add("hidden");
+      openMenu.classList.remove("dropdown-open");
+    }
   }
 
   handleClickOutside(event) {

--- a/app/javascript/controllers/post_context_menu_controller.js
+++ b/app/javascript/controllers/post_context_menu_controller.js
@@ -2,14 +2,16 @@ import { Controller } from "@hotwired/stimulus";
 
 export default class extends Controller {
   static targets = ["menu", "chatBubble"];
-  static classes = ["hidden", "open"];
+  static classes = ["hidden", "open", "fading"];
 
   connect() {
     this.handleClickOutside = this.handleClickOutside.bind(this);
+    this.handleScroll = this.handleScroll.bind(this);
   }
 
   disconnect() {
     document.removeEventListener("click", this.handleClickOutside);
+    document.removeEventListener("scroll", this.handleScroll);
   }
 
   showMenu(event) {
@@ -21,12 +23,20 @@ export default class extends Controller {
     this.menuTarget.classList.add(this.openClass);
     this.positionMenu(event);
     document.addEventListener("click", this.handleClickOutside);
+    document.addEventListener("scroll", this.handleScroll, true);
   }
 
   hideMenu() {
-    this.menuTarget.classList.add(this.hiddenClass);
-    this.menuTarget.classList.remove(this.openClass);
-    document.removeEventListener("click", this.handleClickOutside);
+    this.menuTarget.classList.add(this.fadingClass);
+
+    // トランジション完了後にメニューを完全に閉じる
+    setTimeout(() => {
+      this.menuTarget.classList.add(this.hiddenClass);
+      this.menuTarget.classList.remove(this.openClass);
+      this.menuTarget.classList.remove(this.fadingClass);
+      document.removeEventListener("click", this.handleClickOutside);
+      document.removeEventListener("scroll", this.handleScroll, true);
+    }, 200); // CSSのduration-200と合わせる
   }
 
   // メニューの位置を計算・設定
@@ -49,6 +59,7 @@ export default class extends Controller {
     if (openMenu) {
       openMenu.classList.add(this.hiddenClass);
       openMenu.classList.remove(this.openClass);
+      openMenu.classList.remove(this.fadingClass);
     }
   }
 
@@ -57,5 +68,10 @@ export default class extends Controller {
     if (!this.chatBubbleTarget.contains(event.target)) {
       this.hideMenu();
     }
+  }
+
+  handleScroll() {
+    // スクロール時にメニューを閉じる
+    this.hideMenu();
   }
 }

--- a/app/javascript/controllers/post_context_menu_controller.js
+++ b/app/javascript/controllers/post_context_menu_controller.js
@@ -20,7 +20,7 @@ export default class extends Controller {
     this.menuTarget.classList.remove(this.hiddenClass);
     this.menuTarget.classList.add(this.openClass);
     this.positionMenu(event);
-    this.addClickOutsideListener();
+    document.addEventListener("click", this.handleClickOutside);
   }
 
   hideMenu() {
@@ -38,13 +38,6 @@ export default class extends Controller {
       top: `${event.clientY}px`,
       zIndex: "9999",
     });
-  }
-
-  // クリックアウトサイドのイベントリスナーを追加
-  addClickOutsideListener() {
-    setTimeout(() => {
-      document.addEventListener("click", this.handleClickOutside);
-    }, 0);
   }
 
   // 他のコンテキストメニューを閉じる

--- a/app/javascript/controllers/post_context_menu_controller.js
+++ b/app/javascript/controllers/post_context_menu_controller.js
@@ -1,7 +1,7 @@
 import { Controller } from "@hotwired/stimulus";
 
 export default class extends Controller {
-  static targets = ["menu"];
+  static targets = ["menu", "chatBubble"];
   static classes = ["hidden", "open"];
 
   // 定数
@@ -77,10 +77,8 @@ export default class extends Controller {
   }
 
   handleClickOutside(event) {
-    if (
-      !this.element.contains(event.target) &&
-      !this.menuTarget.contains(event.target)
-    ) {
+    // chat-bubble要素以外をクリックした場合、メニューを閉じる
+    if (!this.chatBubbleTarget.contains(event.target)) {
       this.hideMenu();
     }
   }

--- a/app/javascript/controllers/post_context_menu_controller.js
+++ b/app/javascript/controllers/post_context_menu_controller.js
@@ -1,0 +1,87 @@
+import { Controller } from "@hotwired/stimulus";
+
+export default class extends Controller {
+  static targets = ["menu"];
+  static classes = ["hidden", "open"];
+
+  // 定数
+  MENU_OFFSET = 10;
+
+  connect() {
+    this.handleClickOutside = this.handleClickOutside.bind(this);
+  }
+
+  disconnect() {
+    document.removeEventListener("click", this.handleClickOutside);
+  }
+
+  showMenu(event) {
+    event.preventDefault();
+    event.stopPropagation();
+
+    this.hideAllMenus();
+    this.menuTarget.classList.remove(this.hiddenClass);
+    this.menuTarget.classList.add(this.openClass);
+    this.positionMenu(event);
+    this.addClickOutsideListener();
+  }
+
+  hideMenu() {
+    this.menuTarget.classList.add(this.hiddenClass);
+    this.menuTarget.classList.remove(this.openClass);
+    document.removeEventListener("click", this.handleClickOutside);
+  }
+
+  // メニューの位置を計算・設定
+  positionMenu(event) {
+    const menuRect = this.menuTarget.getBoundingClientRect();
+    const viewport = { width: window.innerWidth, height: window.innerHeight };
+
+    let left = event.clientX;
+    let top = event.clientY;
+
+    // 画面端を考慮した位置調整
+    if (left + menuRect.width > viewport.width) {
+      left = viewport.width - menuRect.width - this.MENU_OFFSET;
+    }
+    if (top + menuRect.height > viewport.height) {
+      top = viewport.height - menuRect.height - this.MENU_OFFSET;
+    }
+
+    // 位置を適用
+    Object.assign(this.menuTarget.style, {
+      position: "fixed",
+      left: `${left}px`,
+      top: `${top}px`,
+      zIndex: "9999",
+    });
+  }
+
+  // クリックアウトサイドのイベントリスナーを追加
+  addClickOutsideListener() {
+    setTimeout(() => {
+      document.addEventListener("click", this.handleClickOutside);
+    }, 0);
+  }
+
+  // 他のコンテキストメニューをすべて閉じる
+  hideAllMenus() {
+    document
+      .querySelectorAll(
+        '[data-controller*="post-context-menu"] [data-post-context-menu-target="menu"]'
+      )
+      .forEach((menu) => {
+        menu.classList.add("hidden");
+        menu.classList.remove("dropdown-open");
+      });
+  }
+
+  handleClickOutside(event) {
+    if (
+      !this.element.contains(event.target) &&
+      !this.menuTarget.contains(event.target)
+    ) {
+      this.hideMenu();
+    }
+  }
+}

--- a/app/views/posts/_context_menu.html.erb
+++ b/app/views/posts/_context_menu.html.erb
@@ -1,17 +1,15 @@
 <!-- 投稿のコンテキストメニュー -->
 <div class="dropdown hidden" data-post-context-menu-target="menu">
   <ul tabindex="0" class="dropdown-content menu bg-custom-white rounded-box z-[1] w-28 p-2 shadow-lg border border-base-300">
-    <% if post.user == current_user %>
-      <li>
-        <%= link_to task_post_path(post.task, post),
-            data: { turbo_method: :delete, turbo_confirm: "この投稿を削除しますか？" },
-            class: "hover:bg-custom-off-white flex items-center gap-2 px-4 py-2 w-full text-left text-custom-rust" do %>
-          <svg xmlns="http://www.w3.org/2000/svg" class="h-4 w-4" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 7l-.867 12.142A2 2 0 0116.138 21H7.862a2 2 0 01-1.995-1.858L5 7m5 4v6m4-6v6m1-10V4a1 1 0 00-1-1h-4a1 1 0 00-1 1v3M4 7h16" />
-          </svg>
-          削除
-        <% end %>
-      </li>
-    <% end %>
+    <li>
+      <%= link_to task_post_path(post.task, post),
+          data: { turbo_method: :delete, turbo_confirm: "この投稿を削除しますか？" },
+          class: "hover:bg-custom-off-white flex items-center gap-2 px-4 py-2 w-full text-left text-custom-rust" do %>
+        <svg xmlns="http://www.w3.org/2000/svg" class="h-4 w-4" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+          <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 7l-.867 12.142A2 2 0 0116.138 21H7.862a2 2 0 01-1.995-1.858L5 7m5 4v6m4-6v6m1-10V4a1 1 0 00-1-1h-4a1 1 0 00-1 1v3M4 7h16" />
+        </svg>
+        削除
+      <% end %>
+    </li>
   </ul>
 </div>

--- a/app/views/posts/_context_menu.html.erb
+++ b/app/views/posts/_context_menu.html.erb
@@ -1,5 +1,5 @@
 <!-- 投稿のコンテキストメニュー -->
-<div class="dropdown hidden" data-post-context-menu-target="menu">
+<div class="dropdown hidden opacity-100 transition-opacity duration-200" data-post-context-menu-target="menu">
   <ul tabindex="0" class="dropdown-content menu bg-custom-white rounded-box z-[1] w-28 p-2 shadow">
     <li>
       <%= link_to task_post_path(post.task, post),

--- a/app/views/posts/_context_menu.html.erb
+++ b/app/views/posts/_context_menu.html.erb
@@ -1,6 +1,6 @@
 <!-- 投稿のコンテキストメニュー -->
 <div class="dropdown hidden" data-post-context-menu-target="menu">
-  <ul tabindex="0" class="dropdown-content menu bg-custom-white rounded-box z-[1] w-28 p-2 shadow-lg border border-base-300">
+  <ul tabindex="0" class="dropdown-content menu bg-custom-white rounded-box z-[1] w-28 p-2 shadow">
     <li>
       <%= link_to task_post_path(post.task, post),
           data: { turbo_method: :delete, turbo_confirm: "この投稿を削除しますか？" },

--- a/app/views/posts/_context_menu.html.erb
+++ b/app/views/posts/_context_menu.html.erb
@@ -4,7 +4,7 @@
     <li>
       <%= link_to task_post_path(post.task, post),
           data: { turbo_method: :delete, turbo_confirm: "この投稿を削除しますか？" },
-          class: "hover:bg-custom-off-white flex items-center gap-2 px-4 py-2 w-full text-left text-custom-rust" do %>
+          class: "bg-custom-white hover:bg-custom-off-white flex items-center gap-2 px-4 py-2 w-full text-left text-custom-rust !text-custom-rust" do %>
         <svg xmlns="http://www.w3.org/2000/svg" class="h-4 w-4" fill="none" viewBox="0 0 24 24" stroke="currentColor">
           <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 7l-.867 12.142A2 2 0 0116.138 21H7.862a2 2 0 01-1.995-1.858L5 7m5 4v6m4-6v6m1-10V4a1 1 0 00-1-1h-4a1 1 0 00-1 1v3M4 7h16" />
         </svg>

--- a/app/views/posts/_context_menu.html.erb
+++ b/app/views/posts/_context_menu.html.erb
@@ -1,0 +1,17 @@
+<!-- 投稿のコンテキストメニュー -->
+<div class="dropdown hidden" data-post-context-menu-target="menu">
+  <ul tabindex="0" class="dropdown-content menu bg-custom-white rounded-box z-[1] w-28 p-2 shadow-lg border border-base-300">
+    <% if post.user == current_user %>
+      <li>
+        <%= link_to task_post_path(post.task, post),
+            data: { turbo_method: :delete, turbo_confirm: "この投稿を削除しますか？" },
+            class: "hover:bg-custom-off-white flex items-center gap-2 px-4 py-2 w-full text-left text-custom-rust" do %>
+          <svg xmlns="http://www.w3.org/2000/svg" class="h-4 w-4" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 7l-.867 12.142A2 2 0 0116.138 21H7.862a2 2 0 01-1.995-1.858L5 7m5 4v6m4-6v6m1-10V4a1 1 0 00-1-1h-4a1 1 0 00-1 1v3M4 7h16" />
+          </svg>
+          削除
+        <% end %>
+      </li>
+    <% end %>
+  </ul>
+</div>

--- a/app/views/posts/_post.html.erb
+++ b/app/views/posts/_post.html.erb
@@ -1,39 +1,41 @@
-<div id="post_<%= post.id %>" class="px-6 py-2" 
+<%= turbo_frame_tag "post_#{post.id}" do %>
+  <div class="px-6 py-2" 
       data-controller="post-context-menu" 
       data-post-context-menu-hidden-class="hidden"
       data-post-context-menu-open-class="dropdown-open">
-  
-  <div class="chat chat-start">
-    <div class="chat-header">
-      <span class="text-sm font-medium text-custom-dark-green">
-        <%= post.user.name %>
-      </span>
-      <span class="text-xs text-custom-dark-green/70 ml-2">
-        <%= post.created_at.strftime("%Y年%m月%d日 %H:%M") %>
-      </span>
+    
+    <div class="chat chat-start">
+      <div class="chat-header">
+        <span class="text-sm font-medium text-custom-dark-green">
+          <%= post.user.name %>
+        </span>
+        <span class="text-xs text-custom-dark-green/70 ml-2">
+          <%= post.created_at.strftime("%Y年%m月%d日 %H:%M") %>
+        </span>
+      </div>
+      <div class="chat-bubble bg-custom-off-white text-custom-dark-green border-none"
+            data-post-context-menu-target="chatBubble"
+            data-action="contextmenu->post-context-menu#showMenu">
+        <%= post.postable.body %>
+      </div>
     </div>
-    <div class="chat-bubble bg-custom-off-white text-custom-dark-green border-none"
-          data-post-context-menu-target="chatBubble"
-          data-action="contextmenu->post-context-menu#showMenu">
-      <%= post.postable.body %>
-    </div>
-  </div>
 
-  <!-- コンテキストメニュー -->
-  <div class="dropdown hidden" data-post-context-menu-target="menu">
-    <ul tabindex="0" class="dropdown-content menu bg-custom-white rounded-box z-[1] w-28 p-2 shadow-lg border border-base-300">
-      <% if post.user == current_user %>
-        <li>
-          <%= link_to task_post_path(post.task, post),
-              data: { turbo_method: :delete, turbo_confirm: "この投稿を削除しますか？" },
-              class: "hover:bg-custom-off-white flex items-center gap-2 px-4 py-2 w-full text-left text-custom-rust" do %>
-            <svg xmlns="http://www.w3.org/2000/svg" class="h-4 w-4" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-              <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 7l-.867 12.142A2 2 0 0116.138 21H7.862a2 2 0 01-1.995-1.858L5 7m5 4v6m4-6v6m1-10V4a1 1 0 00-1-1h-4a1 1 0 00-1 1v3M4 7h16" />
-            </svg>
-            削除
-          <% end %>
-        </li>
-      <% end %>
-    </ul>
+    <!-- コンテキストメニュー -->
+    <div class="dropdown hidden" data-post-context-menu-target="menu">
+      <ul tabindex="0" class="dropdown-content menu bg-custom-white rounded-box z-[1] w-28 p-2 shadow-lg border border-base-300">
+        <% if post.user == current_user %>
+          <li>
+            <%= link_to task_post_path(post.task, post),
+                data: { turbo_method: :delete, turbo_confirm: "この投稿を削除しますか？" },
+                class: "hover:bg-custom-off-white flex items-center gap-2 px-4 py-2 w-full text-left text-custom-rust" do %>
+              <svg xmlns="http://www.w3.org/2000/svg" class="h-4 w-4" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 7l-.867 12.142A2 2 0 0116.138 21H7.862a2 2 0 01-1.995-1.858L5 7m5 4v6m4-6v6m1-10V4a1 1 0 00-1-1h-4a1 1 0 00-1 1v3M4 7h16" />
+              </svg>
+              削除
+            <% end %>
+          </li>
+        <% end %>
+      </ul>
+    </div>
   </div>
-</div>
+<% end %>

--- a/app/views/posts/_post.html.erb
+++ b/app/views/posts/_post.html.erb
@@ -1,4 +1,8 @@
-<div class="px-6 py-2">
+<div id="post_<%= post.id %>" class="px-6 py-2" 
+      data-controller="post-context-menu" 
+      data-post-context-menu-hidden-class="hidden"
+      data-post-context-menu-open-class="dropdown-open">
+  
   <div class="chat chat-start">
     <div class="chat-header">
       <span class="text-sm font-medium text-custom-dark-green">
@@ -8,8 +12,28 @@
         <%= post.created_at.strftime("%Y年%m月%d日 %H:%M") %>
       </span>
     </div>
-    <div class="chat-bubble bg-custom-off-white text-custom-dark-green border-none">
+    <div class="chat-bubble bg-custom-off-white text-custom-dark-green border-none"
+          data-post-context-menu-target="chatBubble"
+          data-action="contextmenu->post-context-menu#showMenu">
       <%= post.postable.body %>
     </div>
+  </div>
+
+  <!-- コンテキストメニュー -->
+  <div class="dropdown hidden" data-post-context-menu-target="menu">
+    <ul tabindex="0" class="dropdown-content menu bg-custom-white rounded-box z-[1] w-28 p-2 shadow-lg border border-base-300">
+      <% if post.user == current_user %>
+        <li>
+          <%= link_to task_post_path(post.task, post),
+              data: { turbo_method: :delete, turbo_confirm: "この投稿を削除しますか？" },
+              class: "hover:bg-custom-off-white flex items-center gap-2 px-4 py-2 w-full text-left text-custom-rust" do %>
+            <svg xmlns="http://www.w3.org/2000/svg" class="h-4 w-4" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+              <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 7l-.867 12.142A2 2 0 0116.138 21H7.862a2 2 0 01-1.995-1.858L5 7m5 4v6m4-6v6m1-10V4a1 1 0 00-1-1h-4a1 1 0 00-1 1v3M4 7h16" />
+            </svg>
+            削除
+          <% end %>
+        </li>
+      <% end %>
+    </ul>
   </div>
 </div>

--- a/app/views/posts/_post.html.erb
+++ b/app/views/posts/_post.html.erb
@@ -4,6 +4,7 @@
       data-post-context-menu-hidden-class="hidden"
       data-post-context-menu-open-class="dropdown-open">
     
+    <!-- 投稿内容 -->
     <div class="chat chat-start">
       <div class="chat-header">
         <span class="text-sm font-medium text-custom-dark-green">
@@ -20,7 +21,7 @@
       </div>
     </div>
 
-    <!-- コンテキストメニュー -->
+    <!-- 投稿のコンテキストメニュー -->
     <div class="dropdown hidden" data-post-context-menu-target="menu">
       <ul tabindex="0" class="dropdown-content menu bg-custom-white rounded-box z-[1] w-28 p-2 shadow-lg border border-base-300">
         <% if post.user == current_user %>

--- a/app/views/posts/_post.html.erb
+++ b/app/views/posts/_post.html.erb
@@ -22,21 +22,6 @@
     </div>
 
     <!-- 投稿のコンテキストメニュー -->
-    <div class="dropdown hidden" data-post-context-menu-target="menu">
-      <ul tabindex="0" class="dropdown-content menu bg-custom-white rounded-box z-[1] w-28 p-2 shadow-lg border border-base-300">
-        <% if post.user == current_user %>
-          <li>
-            <%= link_to task_post_path(post.task, post),
-                data: { turbo_method: :delete, turbo_confirm: "この投稿を削除しますか？" },
-                class: "hover:bg-custom-off-white flex items-center gap-2 px-4 py-2 w-full text-left text-custom-rust" do %>
-              <svg xmlns="http://www.w3.org/2000/svg" class="h-4 w-4" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 7l-.867 12.142A2 2 0 0116.138 21H7.862a2 2 0 01-1.995-1.858L5 7m5 4v6m4-6v6m1-10V4a1 1 0 00-1-1h-4a1 1 0 00-1 1v3M4 7h16" />
-              </svg>
-              削除
-            <% end %>
-          </li>
-        <% end %>
-      </ul>
-    </div>
+    <%= render "posts/context_menu", post: post %>
   </div>
 <% end %>

--- a/app/views/posts/_post.html.erb
+++ b/app/views/posts/_post.html.erb
@@ -2,7 +2,8 @@
   <div class="px-6 py-2" 
       data-controller="post-context-menu" 
       data-post-context-menu-hidden-class="hidden"
-      data-post-context-menu-open-class="dropdown-open">
+      data-post-context-menu-open-class="dropdown-open"
+      data-post-context-menu-fading-class="opacity-0">
     
     <!-- 投稿内容 -->
     <div class="chat chat-start">

--- a/app/views/posts/destroy.turbo_stream.erb
+++ b/app/views/posts/destroy.turbo_stream.erb
@@ -1,0 +1,1 @@
+<%= turbo_stream.remove "post_#{@post.id}" %>

--- a/app/views/tasks/_dropdown.html.erb
+++ b/app/views/tasks/_dropdown.html.erb
@@ -18,7 +18,7 @@
       <!-- 🎓 button_toによる構造 li > form > button は、daisyuiのmenuクラスによるレイアウト調整が機能しないので、link_toを使用した。https://v4.daisyui.com/components/dropdown/#method-2-using-css-focus-->
       <%= link_to task_path(task),
           data: { turbo_method: :delete, turbo_confirm: "削除しますか？" },
-          class: "hover:bg-custom-off-white flex items-center gap-2 px-4 py-2 w-full text-left text-custom-rust" do %>
+          class: "hover:bg-custom-off-white flex items-center gap-2 px-4 py-2 w-full text-left text-custom-rust !text-custom-rust" do %>
         <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" class="size-4">
           <path stroke-linecap="round" stroke-linejoin="round" d="m14.74 9-.346 9m-4.788 0L9.26 9m9.968-3.21c.342 .052 .682 .107 1.022 .166m-1.022-.165L18.16 19.673a2.25 2.25 0 0 1-2.244 2.077H8.084a2.25 2.25 0 0 1-2.244-2.077L4.772 5.79m14.456 0a48.108 48.108 0 0 0-3.478-.397m-12 .562c.34-.059 .68-.114 1.022-.165m0 0a48.11 48.11 0 0 1 3.478-.397m7.5 0v-.916c0-1.18-.91-2.164-2.09-2.201a51.964 51.964 0 0 0-3.32 0c-1.18 .037-2.09 1.022-2.09 2.201v.916m7.5 0a48.667 48.667 0 0 0-7.5 0" />
         </svg>

--- a/config/application.rb
+++ b/config/application.rb
@@ -27,5 +27,8 @@ module Myapp
     # デフォルトロケールを日本語に設定
     config.i18n.default_locale = :ja
     config.i18n.available_locales = [ :ja, :en ]
+    
+    # タイムゾーンを日本時間に設定
+    config.time_zone = 'Asia/Tokyo'
   end
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -11,7 +11,7 @@ Rails.application.routes.draw do
 
   resources :tasks do
     patch :toggle_status, on: :member # toggle_statusというカスタムアクションの追加
-    resources :posts, only: [ :create ]
+    resources :posts, only: [ :create, :destroy ]
     resources :todos, only: [ :update ]
   end
 


### PR DESCRIPTION
## 概要
タスク詳細画面において、ポストの削除機能を実装する。

## 実装
### ポストの削除機能
- 投稿されたポストを右クリックすると、コンテキストメニューが表示され、タスクの削除を選択できる。

#### 投稿のコンテキストメニューのパーシャル
```ruby
# app/views/posts/_context_menu.html.erb

<!-- 投稿のコンテキストメニュー -->
<div class="dropdown hidden opacity-100 transition-opacity duration-200" data-post-context-menu-target="menu">
  <ul tabindex="0" class="dropdown-content menu bg-custom-white rounded-box z-[1] w-28 p-2 shadow">
    <li>
      <%= link_to task_post_path(post.task, post),
          data: { turbo_method: :delete, turbo_confirm: "この投稿を削除しますか？" },
          class: "bg-custom-white hover:bg-custom-off-white flex items-center gap-2 px-4 py-2 w-full text-left text-custom-rust !text-custom-rust" do %>
        <svg xmlns="http://www.w3.org/2000/svg" class="h-4 w-4" fill="none" viewBox="0 0 24 24" stroke="currentColor">
          <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 7l-.867 12.142A2 2 0 0116.138 21H7.862a2 2 0 01-1.995-1.858L5 7m5 4v6m4-6v6m1-10V4a1 1 0 00-1-1h-4a1 1 0 00-1 1v3M4 7h16" />
        </svg>
        削除
      <% end %>
    </li>
  </ul>
</div>
```

#### 投稿一覧画面
<img width="2536" height="536" alt="image" src="https://github.com/user-attachments/assets/4409efd9-13ae-4e18-b04f-d8cb62763e68" />


- 「削除」をクリックするとポストを削除する。TextPostとPost両方を削除する。
-  ポスト外をクリックするとコンテキストメニューが閉じる
-  スクロールするとコンテキストメニューが閉じる

### Postシステムスペックの作成
- 投稿削除