### PR TITLE
【タスク詳細画面】ドキュメント型ポストの投稿

### DIFF
--- a/app/controllers/posts_controller.rb
+++ b/app/controllers/posts_controller.rb
@@ -4,11 +4,21 @@ class PostsController < ApplicationController
 
   def create
     # ネストした属性を使用して一度に作成
-    @post = @task.posts.build(
-      user: current_user,
-      postable_type: post_params[:postable_type],
-      postable_attributes: post_params[:postable_attributes]
-    )
+    if post_params[:postable_type] == "DocumentPost"
+      document_url = post_params[:postable_attributes][:url]
+      document = Document.find_or_create_by(url: document_url)
+      @post = @task.posts.build(
+        user: current_user,
+        postable_type: post_params[:postable_type],
+        postable_attributes: { document_id: document.id }
+      )
+    elsif post_params[:postable_type] == "TextPost"
+      @post = @task.posts.build(
+        user: current_user,
+        postable_type: post_params[:postable_type],
+        postable_attributes: post_params[:postable_attributes]
+      )
+    end
 
     if @post.save
       respond_to do |format|
@@ -44,6 +54,6 @@ class PostsController < ApplicationController
   end
 
   def post_params
-    params.require(:post).permit(:postable_type, postable_attributes: [ :body ])
+    params.require(:post).permit(:postable_type, postable_attributes: [ :body, :url ])
   end
 end

--- a/app/models/document.rb
+++ b/app/models/document.rb
@@ -1,0 +1,5 @@
+class Document < ApplicationRecord
+  has_many :document_posts, dependent: :destroy
+  
+  validates :url, presence: true, uniqueness: true
+end

--- a/app/models/document.rb
+++ b/app/models/document.rb
@@ -1,5 +1,5 @@
 class Document < ApplicationRecord
   has_many :document_posts, dependent: :destroy
-  
+
   validates :url, presence: true, uniqueness: true
 end

--- a/app/models/document_post.rb
+++ b/app/models/document_post.rb
@@ -1,5 +1,5 @@
 class DocumentPost < ApplicationRecord
   belongs_to :document
-  
+
   validates :document_id, presence: true
 end

--- a/app/models/document_post.rb
+++ b/app/models/document_post.rb
@@ -1,0 +1,5 @@
+class DocumentPost < ApplicationRecord
+  belongs_to :document
+  
+  validates :document_id, presence: true
+end

--- a/app/models/post.rb
+++ b/app/models/post.rb
@@ -1,6 +1,6 @@
 class Post < ApplicationRecord
   belongs_to :task
   belongs_to :user
-  delegated_type :postable, types: %w[TextPost], dependent: :destroy
+  delegated_type :postable, types: %w[TextPost DocumentPost], dependent: :destroy
   accepts_nested_attributes_for :postable
 end

--- a/app/views/posts/_form.html.erb
+++ b/app/views/posts/_form.html.erb
@@ -2,8 +2,9 @@
   <!-- daisyUI Radio Tabs Lifted -->
   <div role="tablist" class="tabs tabs-lifted">
     <!-- ♻️ daisyUIコンポーネント特有のスタイルを変更するために、inputタグの背景色とボーダー色をstyle属性により強制的に設定した。
+    背景色は、bg-custom-white、ボーダー色は、border-custom-light-gray/50である。
     ここはdaisyUIやtailwindcss特有の設定方法がある可能性があるので、今後同じスタイルを使用する場合は改善の余地あり。 -->
-    <input type="radio" name="post_type" role="tab" class="tab" style="background-color: #FCFCF9; border-color: #E8E8E2;" aria-label="テキスト" checked />
+    <input type="radio" name="post_type" role="tab" class="tab" style="background-color: #FCFCF9; border-color: rgba(232, 232, 226, 0.5);" aria-label="テキスト" checked />
     <div role="tabpanel" class="tab-content bg-custom-white border-custom-light-gray/50 rounded-box p-6">
       <!-- TextPost フォーム -->
       <%= form_with model: post, url: task_posts_path(task), method: :post, class: "space-y-4", id: "text-post-form" do |f| %>
@@ -22,7 +23,7 @@
       <% end %>
     </div>
 
-    <input type="radio" name="post_type" role="tab" class="tab" style="background-color: #FCFCF9; border-color: #E8E8E2;" aria-label="ドキュメント" />
+    <input type="radio" name="post_type" role="tab" class="tab" style="background-color: #FCFCF9; border-color: rgba(232, 232, 226, 0.5);" aria-label="ドキュメント" />
     <div role="tabpanel" class="tab-content bg-custom-white border-custom-light-gray/50 rounded-box p-6">
       <!-- DocumentPost フォーム -->
       <%= form_with model: post, url: task_posts_path(task), method: :post, class: "space-y-4", id: "document-post-form" do |f| %>

--- a/app/views/posts/_form.html.erb
+++ b/app/views/posts/_form.html.erb
@@ -1,19 +1,45 @@
 <div class="bg-custom-white rounded-lg shadow-lg p-6 border border-custom-light-gray/50">
-  <%= form_with model: post, url: task_posts_path(task), method: :post, class: "space-y-4" do |f| %>
-    <!-- postable_typeを明示的に指定 -->
-    <%= f.hidden_field :postable_type, value: "TextPost" %>
-    
-    <div class="form-control">
-      <%= f.fields_for :postable_attributes do |text_post_form| %>
-        <%= text_post_form.text_area :body, 
-            placeholder: "コメントを入力してください...", 
-            class: "textarea textarea-bordered w-full h-24 bg-custom-white border-custom-dark-green text-custom-dark-green focus:border-custom-dark-green focus:ring-2 focus:ring-custom-dark-green/20 focus:outline-none placeholder:text-custom-dark-green/50" %>
+  <!-- daisyUI Radio Tabs Lifted -->
+  <div role="tablist" class="tabs tabs-lifted">
+    <input type="radio" name="post_type" role="tab" class="tab" aria-label="テキスト" checked />
+    <div role="tabpanel" class="tab-content bg-base-100 border-base-300 rounded-box p-6">
+      <!-- TextPost フォーム -->
+      <%= form_with model: post, url: task_posts_path(task), method: :post, class: "space-y-4", id: "text-post-form" do |f| %>
+        <%= f.hidden_field :postable_type, value: "TextPost" %>
+        
+        <div class="form-control">
+          <%= f.fields_for :postable_attributes do |text_post_form| %>
+            <%= text_post_form.text_area :body, 
+                placeholder: "コメントを入力してください...", 
+                class: "textarea textarea-bordered w-full h-24 bg-custom-white border-custom-dark-green text-custom-dark-green focus:border-custom-dark-green focus:ring-2 focus:ring-custom-dark-green/20 focus:outline-none placeholder:text-custom-dark-green/50" %>
+          <% end %>
+        </div>
+        <div class="flex justify-end gap-4">
+          <%= f.submit "投稿", class: "btn bg-custom-green hover:bg-custom-green/80 text-custom-white border-none" %>
+        </div>
       <% end %>
     </div>
-    <div class="flex justify-end gap-4">
-      <%= f.submit "投稿", class: "btn bg-custom-green hover:bg-custom-green/80 text-custom-white border-none" %>
+
+    <input type="radio" name="post_type" role="tab" class="tab" aria-label="ドキュメント" />
+    <div role="tabpanel" class="tab-content bg-base-100 border-base-300 rounded-box p-6">
+      <!-- DocumentPost フォーム -->
+      <%= form_with model: post, url: task_posts_path(task), method: :post, class: "space-y-4", id: "document-post-form" do |f| %>
+        <%= f.hidden_field :postable_type, value: "DocumentPost" %>
+        
+        <div class="form-control">
+          <%= f.fields_for :postable_attributes do |document_post_form| %>
+            <%= document_post_form.label :document_url, "URL", class: "label" %>
+            <%= document_post_form.text_field :document_url, 
+                placeholder: "https://docs.example.com", 
+                class: "input input-bordered w-full" %>
+          <% end %>
+        </div>
+        <div class="flex justify-end gap-4">
+          <%= f.submit "投稿", class: "btn bg-custom-green hover:bg-custom-green/80 text-custom-white border-none" %>
+        </div>
+      <% end %>
     </div>
-  <% end %>
+  </div>
 
   <!-- ⚠️ 上記のform_withタグ内で実装を行なっても、完了ボタンを押した場合、patchリクエストのurlがtask_post_path(task)になってしまい、ルーティングエラーが発生する。
     そのため、form_withタグの外でボタン群を実装することで、完了ボタンを押した時、patchリクエストは正常に動作し、タスクのステータスをトグルすることができた。

--- a/app/views/posts/_form.html.erb
+++ b/app/views/posts/_form.html.erb
@@ -4,7 +4,7 @@
     <!-- ♻️ daisyUIコンポーネント特有のスタイルを変更するために、inputタグの背景色とボーダー色をstyle属性により強制的に設定した。
     背景色は、bg-custom-white、ボーダー色は、border-custom-light-gray/50である。
     ここはdaisyUIやtailwindcss特有の設定方法がある可能性があるので、今後同じスタイルを使用する場合は改善の余地あり。 -->
-    <input type="radio" name="post_type" role="tab" class="tab" style="background-color: #FCFCF9; border-color: rgba(232, 232, 226, 0.5);" aria-label="テキスト" checked />
+    <input type="radio" name="post_type" role="tab" class="tab text-custom-dark-green" style="background-color: #FCFCF9; border-color: rgba(232, 232, 226, 0.5);" aria-label="テキスト" checked />
     <div role="tabpanel" class="tab-content bg-custom-white border-custom-light-gray/50 rounded-box p-6">
       <!-- TextPost フォーム -->
       <%= form_with model: post, url: task_posts_path(task), method: :post, class: "space-y-4", id: "text-post-form" do |f| %>
@@ -23,7 +23,7 @@
       <% end %>
     </div>
 
-    <input type="radio" name="post_type" role="tab" class="tab" style="background-color: #FCFCF9; border-color: rgba(232, 232, 226, 0.5);" aria-label="ドキュメント" />
+    <input type="radio" name="post_type" role="tab" class="tab text-custom-dark-green" style="background-color: #FCFCF9; border-color: rgba(232, 232, 226, 0.5);" aria-label="ドキュメント" />
     <div role="tabpanel" class="tab-content bg-custom-white border-custom-light-gray/50 rounded-box p-6">
       <!-- DocumentPost フォーム -->
       <%= form_with model: post, url: task_posts_path(task), method: :post, class: "space-y-4", id: "document-post-form" do |f| %>
@@ -31,10 +31,10 @@
         
         <div class="form-control">
           <%= f.fields_for :postable_attributes do |document_post_form| %>
-            <%= document_post_form.label :document_url, "URL", class: "label" %>
+            <%= document_post_form.label :document_url, "URL", class: "label text-custom-dark-green" %>
             <%= document_post_form.text_field :document_url, 
                 placeholder: "https://docs.example.com", 
-                class: "input input-bordered w-full" %>
+                class: "input input-bordered w-full bg-custom-white border-custom-dark-green text-custom-dark-green focus:border-custom-dark-green focus:ring-2 focus:ring-custom-dark-green/20 focus:outline-none placeholder:text-custom-dark-green/50" %>
           <% end %>
         </div>
         <div class="flex justify-end gap-4">

--- a/app/views/posts/_form.html.erb
+++ b/app/views/posts/_form.html.erb
@@ -31,8 +31,8 @@
         
         <div class="form-control">
           <%= f.fields_for :postable_attributes do |document_post_form| %>
-            <%= document_post_form.label :document_url, "URL", class: "label text-custom-dark-green" %>
-            <%= document_post_form.text_field :document_url, 
+            <%= document_post_form.label :url, "URL", class: "label text-custom-dark-green" %>
+            <%= document_post_form.text_field :url, 
                 placeholder: "https://docs.example.com", 
                 class: "input input-bordered w-full bg-custom-white border-custom-dark-green text-custom-dark-green focus:border-custom-dark-green focus:ring-2 focus:ring-custom-dark-green/20 focus:outline-none placeholder:text-custom-dark-green/50" %>
           <% end %>

--- a/app/views/posts/_form.html.erb
+++ b/app/views/posts/_form.html.erb
@@ -1,8 +1,10 @@
-<div class="bg-custom-white rounded-lg shadow-lg p-6 border border-custom-light-gray/50">
+<div class="bg-custom-white rounded-2xl shadow-lg border border-custom-light-gray/50">
   <!-- daisyUI Radio Tabs Lifted -->
   <div role="tablist" class="tabs tabs-lifted">
-    <input type="radio" name="post_type" role="tab" class="tab" aria-label="テキスト" checked />
-    <div role="tabpanel" class="tab-content bg-base-100 border-base-300 rounded-box p-6">
+    <!-- ♻️ daisyUIコンポーネント特有のスタイルを変更するために、inputタグの背景色とボーダー色をstyle属性により強制的に設定した。
+    ここはdaisyUIやtailwindcss特有の設定方法がある可能性があるので、今後同じスタイルを使用する場合は改善の余地あり。 -->
+    <input type="radio" name="post_type" role="tab" class="tab" style="background-color: #FCFCF9; border-color: #E8E8E2;" aria-label="テキスト" checked />
+    <div role="tabpanel" class="tab-content bg-custom-white border-custom-light-gray/50 rounded-box p-6">
       <!-- TextPost フォーム -->
       <%= form_with model: post, url: task_posts_path(task), method: :post, class: "space-y-4", id: "text-post-form" do |f| %>
         <%= f.hidden_field :postable_type, value: "TextPost" %>
@@ -20,8 +22,8 @@
       <% end %>
     </div>
 
-    <input type="radio" name="post_type" role="tab" class="tab" aria-label="ドキュメント" />
-    <div role="tabpanel" class="tab-content bg-base-100 border-base-300 rounded-box p-6">
+    <input type="radio" name="post_type" role="tab" class="tab" style="background-color: #FCFCF9; border-color: #E8E8E2;" aria-label="ドキュメント" />
+    <div role="tabpanel" class="tab-content bg-custom-white border-custom-light-gray/50 rounded-box p-6">
       <!-- DocumentPost フォーム -->
       <%= form_with model: post, url: task_posts_path(task), method: :post, class: "space-y-4", id: "document-post-form" do |f| %>
         <%= f.hidden_field :postable_type, value: "DocumentPost" %>

--- a/app/views/posts/_post.html.erb
+++ b/app/views/posts/_post.html.erb
@@ -18,7 +18,11 @@
       <div class="chat-bubble bg-custom-off-white text-custom-dark-green border-none"
             data-post-context-menu-target="chatBubble"
             data-action="contextmenu->post-context-menu#showMenu">
-        <%= post.postable.body %>
+        <% if post.postable_type == 'TextPost' %>
+          <%= post.postable.body %>
+        <% elsif post.postable_type == 'DocumentPost' %>
+          <%= post.postable.document.url %>
+        <% end %>
       </div>
     </div>
 

--- a/db/migrate/20251001054201_create_documents.rb
+++ b/db/migrate/20251001054201_create_documents.rb
@@ -1,0 +1,10 @@
+class CreateDocuments < ActiveRecord::Migration[7.2]
+  def change
+    create_table :documents do |t|
+      t.string :url, null: false
+
+      t.timestamps
+    end
+    add_index :documents, :url, unique: true
+  end
+end

--- a/db/migrate/20251001054602_create_document_posts.rb
+++ b/db/migrate/20251001054602_create_document_posts.rb
@@ -1,0 +1,9 @@
+class CreateDocumentPosts < ActiveRecord::Migration[7.2]
+  def change
+    create_table :document_posts do |t|
+      t.references :document, null: false, foreign_key: true
+
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,9 +10,23 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.2].define(version: 2025_07_24_085758) do
+ActiveRecord::Schema[7.2].define(version: 2025_10_01_054602) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
+
+  create_table "document_posts", force: :cascade do |t|
+    t.bigint "document_id", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["document_id"], name: "index_document_posts_on_document_id"
+  end
+
+  create_table "documents", force: :cascade do |t|
+    t.string "url", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["url"], name: "index_documents_on_url", unique: true
+  end
 
   create_table "posts", force: :cascade do |t|
     t.bigint "task_id", null: false
@@ -77,6 +91,7 @@ ActiveRecord::Schema[7.2].define(version: 2025_07_24_085758) do
     t.index ["reset_password_token"], name: "index_users_on_reset_password_token", unique: true
   end
 
+  add_foreign_key "document_posts", "documents"
   add_foreign_key "posts", "tasks"
   add_foreign_key "posts", "users"
   add_foreign_key "tasks", "users"

--- a/spec/factories/document_posts.rb
+++ b/spec/factories/document_posts.rb
@@ -1,0 +1,7 @@
+FactoryBot.define do
+  factory :document_post do
+    association :document
+  end
+end
+
+

--- a/spec/factories/document_posts.rb
+++ b/spec/factories/document_posts.rb
@@ -3,5 +3,3 @@ FactoryBot.define do
     association :document
   end
 end
-
-

--- a/spec/factories/documents.rb
+++ b/spec/factories/documents.rb
@@ -3,5 +3,3 @@ FactoryBot.define do
     sequence(:url) { |n| "https://docs.example.com/#{n}" }
   end
 end
-
-

--- a/spec/factories/documents.rb
+++ b/spec/factories/documents.rb
@@ -1,0 +1,7 @@
+FactoryBot.define do
+  factory :document do
+    sequence(:url) { |n| "https://docs.example.com/#{n}" }
+  end
+end
+
+

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -47,6 +47,7 @@ RSpec.configure do |config|
 
   # Deviseのテストヘルパーを追加
   config.include Devise::Test::IntegrationHelpers, type: :system
+  config.include Devise::Test::IntegrationHelpers, type: :request
   config.include Devise::Test::ControllerHelpers, type: :controller
   config.include Devise::Test::ControllerHelpers, type: :view
 

--- a/spec/requests/posts_spec.rb
+++ b/spec/requests/posts_spec.rb
@@ -1,0 +1,69 @@
+require 'rails_helper'
+
+RSpec.describe 'Posts', type: :request do
+  let(:user) { create(:user) }
+  let(:task) { create(:task, user: user) }
+
+  before do
+    sign_in user
+  end
+
+  describe 'POST /tasks/:task_id/posts' do
+    context 'TextPost作成' do
+      context '正常な入力の場合' do
+        it 'PostとTextPostが正常に作成される' do
+          post_params = {
+            post: {
+              postable_type: 'TextPost',
+              postable_attributes: { body: 'test_text_post' }
+            }
+          }
+
+          expect {
+            post task_posts_path(task), params: post_params
+          }.to change(Post, :count).by(1)
+            .and change(TextPost, :count).by(1)
+
+          expect(response).to have_http_status(:redirect)
+          expect(Post.last.postable_type).to eq('TextPost')
+          expect(Post.last.postable.body).to eq('test_text_post')
+        end
+      end
+    end
+
+    context 'DocumentPost作成' do
+      context '正常な入力の場合' do
+        it 'PostとDocumentPostとDocumentが正常に作成される' do
+          post_params = {
+            post: {
+              postable_type: 'DocumentPost',
+              postable_attributes: { url: 'https://docs.example.com' }
+            }
+          }
+
+          expect {
+            post task_posts_path(task), params: post_params
+          }.to change(Post, :count).by(1)
+            .and change(DocumentPost, :count).by(1)
+            .and change(Document, :count).by(1)
+
+          expect(response).to have_http_status(:redirect)
+          
+          # Documentレコードが作成されることを確認
+          document = Document.find_by(url: 'https://docs.example.com')
+          expect(document).to be_present
+          
+          # DocumentPostレコードが作成され、Documentと関連付けられることを確認
+          document_post = DocumentPost.last
+          expect(document_post).to be_present
+          expect(document_post.document_id).to eq(document.id)
+          
+          # PostレコードがDocumentPostと関連付けられることを確認
+          post = Post.last
+          expect(post.postable_type).to eq('DocumentPost')
+          expect(post.postable).to eq(document_post)
+        end
+      end
+    end
+  end
+end

--- a/spec/requests/posts_spec.rb
+++ b/spec/requests/posts_spec.rb
@@ -48,16 +48,16 @@ RSpec.describe 'Posts', type: :request do
             .and change(Document, :count).by(1)
 
           expect(response).to have_http_status(:redirect)
-          
+
           # Documentレコードが作成されることを確認
           document = Document.find_by(url: 'https://docs.example.com')
           expect(document).to be_present
-          
+
           # DocumentPostレコードが作成され、Documentと関連付けられることを確認
           document_post = DocumentPost.last
           expect(document_post).to be_present
           expect(document_post.document_id).to eq(document.id)
-          
+
           # PostレコードがDocumentPostと関連付けられることを確認
           post = Post.last
           expect(post.postable_type).to eq('DocumentPost')

--- a/spec/system/posts_spec.rb
+++ b/spec/system/posts_spec.rb
@@ -15,7 +15,10 @@ RSpec.describe 'Posts', type: :system do
       context '正常な入力の場合' do
         it 'TextPostが正常に作成される' do
           fill_in 'post[postable_attributes][body]', with: 'test_text_post'
-          click_button '投稿'
+          # text-post-formというidを持つformタグ内で投稿ボタンをクリック
+          within('#text-post-form') do
+            click_button '投稿'
+          end
 
           expect(page).to have_content('test_text_post')
           # expect(page).to have_content('コメントが投稿されました。')
@@ -26,7 +29,9 @@ RSpec.describe 'Posts', type: :system do
       context 'バリデーションエラーが発生する場合' do
         it 'bodyが空の場合、エラーメッセージが表示される' do
           fill_in 'post[postable_attributes][body]', with: ''
-          click_button '投稿'
+          within('#text-post-form') do
+            click_button '投稿'
+          end
 
           # expect(page).to have_content('コメントの内容が無効です。')
           expect(current_path).to eq task_path(task)
@@ -34,7 +39,9 @@ RSpec.describe 'Posts', type: :system do
 
         it 'bodyが501文字以上の場合、エラーメッセージが表示される' do
           fill_in 'post[postable_attributes][body]', with: 'a' * 501
-          click_button '投稿'
+          within('#text-post-form') do
+            click_button '投稿'
+          end
 
           # expect(page).to have_content('コメントの内容が無効です。')
           expect(current_path).to eq task_path(task)

--- a/spec/system/posts_spec.rb
+++ b/spec/system/posts_spec.rb
@@ -79,7 +79,7 @@ RSpec.describe 'Posts', type: :system do
       end
 
       context 'TextPostが存在する場合' do
-        it 'TextPost一覧が正しく表示される' do
+        it '投稿一覧にTextPostが正しく表示される' do
           expect(page).to have_content('test_text_post')
           expect(page).to have_content(user.name)
           expect(page).to have_content(post.created_at.strftime("%Y年%m月%d日 %H:%M"))

--- a/spec/system/posts_spec.rb
+++ b/spec/system/posts_spec.rb
@@ -71,7 +71,9 @@ RSpec.describe 'Posts', type: :system do
   describe '投稿表示' do
     context '投稿が存在する場合' do
       let(:task) { create(:task, user: user) }
-      let!(:post) { create(:post, user: user, task: task, postable: create(:text_post, body: 'test_text_post')) }
+      let!(:text_post) { create(:post, user: user, task: task, postable: create(:text_post, body: 'test_text_post')) }
+      let!(:document) { create(:document, url: 'https://docs.example.com') }
+      let!(:document_post) { create(:post, user: user, task: task, postable: create(:document_post, document: document)) }
 
       before do
         sign_in user
@@ -82,7 +84,13 @@ RSpec.describe 'Posts', type: :system do
         it '投稿一覧にTextPostが正しく表示される' do
           expect(page).to have_content('test_text_post')
           expect(page).to have_content(user.name)
-          expect(page).to have_content(post.created_at.strftime("%Y年%m月%d日 %H:%M"))
+          expect(page).to have_content(text_post.created_at.strftime("%Y年%m月%d日 %H:%M"))
+        end
+
+        it '投稿一覧にDocumentPostが正しく表示される' do
+          expect(page).to have_content('https://docs.example.com')
+          expect(page).to have_content(user.name)
+          expect(page).to have_content(document_post.created_at.strftime("%Y年%m月%d日 %H:%M"))
         end
       end
     end

--- a/spec/system/posts_spec.rb
+++ b/spec/system/posts_spec.rb
@@ -54,7 +54,7 @@ RSpec.describe 'Posts', type: :system do
         it 'DocumentPostが正常に作成される' do
           # DocumentPost投稿フォームのタブをクリック
           find('input[aria-label="ドキュメント"]').click
-          
+
           fill_in 'post[postable_attributes][url]', with: 'https://docs.example.com'
           within('#document-post-form') do
             click_button '投稿'

--- a/spec/system/posts_spec.rb
+++ b/spec/system/posts_spec.rb
@@ -60,24 +60,6 @@ RSpec.describe 'Posts', type: :system do
             click_button '投稿'
           end
 
-          # ⚠️ 以下のテストはデータベースレベルのテストなので、統合テストではなくモデルレベルのテストで行うべきだという判断。
-
-          # DocumentPost投稿時に、DocumentPostレコードとそれに紐づくDocumentレコードが正しく作成されているか確認
-          # 1. Documentテーブルに投稿したURLを含むレコードが存在するか
-          # document = Document.find_by(url: 'https://docs.example.com')
-          # expect(document).to be_present
-          
-          # 2. DocumentPostテーブルのdocument_idが作成したDocumentレコードのidと一致するか
-          # document_post = DocumentPost.last
-          # expect(document_post).to be_present
-          # expect(document_post.document_id).to eq(document.id)
-          
-          # 3. 最新の投稿がDocumentPostであり、PostレコードとDocumentPostレコードが紐づいているか確認
-          # post = Post.last
-          # expect(post).to be_present
-          # expect(post.postable_type).to eq('DocumentPost')
-          # expect(post.postable).to eq(document_post)
-
           # ポスト一覧に投稿されたDocumentPostが表示されることを確認
           expect(page).to have_content('https://docs.example.com')
           expect(current_path).to eq task_path(task)

--- a/spec/system/posts_spec.rb
+++ b/spec/system/posts_spec.rb
@@ -48,6 +48,42 @@ RSpec.describe 'Posts', type: :system do
         end
       end
     end
+
+    context 'DocumentPost作成' do
+      context '正常な入力の場合' do
+        it 'DocumentPostが正常に作成される' do
+          # DocumentPost投稿フォームのタブをクリック
+          find('input[aria-label="ドキュメント"]').click
+          
+          fill_in 'post[postable_attributes][url]', with: 'https://docs.example.com'
+          within('#document-post-form') do
+            click_button '投稿'
+          end
+
+          # ⚠️ 以下のテストはデータベースレベルのテストなので、統合テストではなくモデルレベルのテストで行うべきだという判断。
+
+          # DocumentPost投稿時に、DocumentPostレコードとそれに紐づくDocumentレコードが正しく作成されているか確認
+          # 1. Documentテーブルに投稿したURLを含むレコードが存在するか
+          # document = Document.find_by(url: 'https://docs.example.com')
+          # expect(document).to be_present
+          
+          # 2. DocumentPostテーブルのdocument_idが作成したDocumentレコードのidと一致するか
+          # document_post = DocumentPost.last
+          # expect(document_post).to be_present
+          # expect(document_post.document_id).to eq(document.id)
+          
+          # 3. 最新の投稿がDocumentPostであり、PostレコードとDocumentPostレコードが紐づいているか確認
+          # post = Post.last
+          # expect(post).to be_present
+          # expect(post.postable_type).to eq('DocumentPost')
+          # expect(post.postable).to eq(document_post)
+
+          # ポスト一覧に投稿されたDocumentPostが表示されることを確認
+          expect(page).to have_content('https://docs.example.com')
+          expect(current_path).to eq task_path(task)
+        end
+      end
+    end
   end
 
   describe '投稿表示' do


### PR DESCRIPTION
## 概要
タスク詳細画面にて、ドキュメント型ポスト専用の投稿フォームからポストを投稿する機能を実装した。

### 関連するissue
- #135 

## 変更点

### ドキュメント型ポストに関するテーブル・モデルの作成
- [x] DocumentPostテーブル・モデルの作成
- [x] Documentテーブル・モデルの作成

### タスク詳細画面における投稿フォームのUIを修正
- [x] daisyUIのタブコンポーネントを使い、2種類の投稿フォーム（ドキュメント型ポスト専用とテキスト型ポスト専用）を選択可能にした
参考資料: https://v4.daisyui.com/components/tab/

- [x] ドキュメント型ポスト専用の投稿フォームを実装

#### テキスト型ポスト用投稿フォームのUI
<img width="2532" height="522" alt="image" src="https://github.com/user-attachments/assets/f5e6938d-0a71-42c1-8b84-96a03c8b74f8" />

#### ドキュメント型ポスト用投稿フォームのUI
<img width="2532" height="506" alt="image" src="https://github.com/user-attachments/assets/493650dd-2b1a-4c0b-8f0d-19b6971577c8" />

