### PR TITLE
Documentモデルにバリデーションを追加

### DIFF
--- a/app/controllers/posts_controller.rb
+++ b/app/controllers/posts_controller.rb
@@ -6,12 +6,27 @@ class PostsController < ApplicationController
     # ネストした属性を使用して一度に作成
     if post_params[:postable_type] == "DocumentPost"
       document_url = post_params[:postable_attributes][:url]
-      document = Document.find_or_create_by(url: document_url)
-      @post = @task.posts.build(
-        user: current_user,
-        postable_type: post_params[:postable_type],
-        postable_attributes: { document_id: document.id }
-      )
+      document = Document.new(url: document_url)
+      
+      # Documentのバリデーションを実行
+      unless document.valid?
+        @post = @task.posts.build(
+          user: current_user,
+          postable_type: post_params[:postable_type],
+          postable_attributes: { document: document }
+        )
+        # DocumentのエラーをPostに転送
+        document.errors.each do |error|
+          @post.errors.add(:base, "URL #{error.message}")
+        end
+      else
+        document.save
+        @post = @task.posts.build(
+          user: current_user,
+          postable_type: post_params[:postable_type],
+          postable_attributes: { document_id: document.id }
+        )
+      end
     elsif post_params[:postable_type] == "TextPost"
       @post = @task.posts.build(
         user: current_user,
@@ -20,7 +35,7 @@ class PostsController < ApplicationController
       )
     end
 
-    if @post.save
+    if @post.errors.empty? && @post.save
       respond_to do |format|
         format.turbo_stream { render :create }
         format.html { redirect_to @task, notice: "コメントが投稿されました。" }

--- a/app/models/document.rb
+++ b/app/models/document.rb
@@ -2,4 +2,20 @@ class Document < ApplicationRecord
   has_many :document_posts, dependent: :destroy
 
   validates :url, presence: true, uniqueness: true
+  validate :url_format_validation
+
+  private
+
+  def url_format_validation
+    return if url.blank?
+
+    begin
+      uri = URI.parse(url)
+      unless uri.is_a?(URI::HTTP) || uri.is_a?(URI::HTTPS)
+        errors.add(:url, :invalid_protocol)
+      end
+    rescue URI::InvalidURIError
+      errors.add(:url, :invalid_url_format)
+    end
+  end
 end

--- a/app/views/posts/_form.html.erb
+++ b/app/views/posts/_form.html.erb
@@ -28,6 +28,9 @@
 
     <input type="radio" name="post_type" role="tab" class="tab text-custom-dark-green" style="background-color: #FCFCF9; border-color: rgba(232, 232, 226, 0.5);" aria-label="ドキュメント" />
     <div role="tabpanel" class="tab-content bg-custom-white border-custom-light-gray/50 rounded-box p-6">
+      <!-- DocumentPost エラーメッセージ -->
+      <%= render 'shared/inline_error_messages', object: post %>
+      
       <!-- DocumentPost フォーム -->
       <%= form_with model: post, url: task_posts_path(task), method: :post, class: "space-y-4", id: "document-post-form" do |f| %>
         <%= f.hidden_field :postable_type, value: "DocumentPost" %>

--- a/app/views/posts/_form.html.erb
+++ b/app/views/posts/_form.html.erb
@@ -6,7 +6,7 @@
     ここはdaisyUIやtailwindcss特有の設定方法がある可能性があるので、今後同じスタイルを使用する場合は改善の余地あり。 -->
     <input type="radio" name="post_type" role="tab" class="tab text-custom-dark-green" style="background-color: #FCFCF9; border-color: rgba(232, 232, 226, 0.5);" aria-label="テキスト" checked />
     <div role="tabpanel" class="tab-content bg-custom-white border-custom-light-gray/50 rounded-box p-6">
-      <!-- エラーメッセージ -->
+      <!-- TextPost エラーメッセージ -->
       <%= render 'shared/inline_error_messages', object: post %>
       
       <!-- TextPost フォーム -->

--- a/app/views/posts/_form.html.erb
+++ b/app/views/posts/_form.html.erb
@@ -14,7 +14,7 @@
         <%= f.hidden_field :postable_type, value: "TextPost" %>
         
         <div class="form-control">
-          <%= f.fields_for :postable_attributes, (post.postable || TextPost.new) do |text_post_form| %>
+          <%= f.fields_for :postable_attributes, (post.postable.is_a?(TextPost) ? post.postable : TextPost.new) do |text_post_form| %>
             <%= text_post_form.text_area :body, 
                 placeholder: "コメントを入力してください...", 
                 class: "textarea textarea-bordered w-full h-24 bg-custom-white border-custom-dark-green text-custom-dark-green focus:border-custom-dark-green focus:ring-2 focus:ring-custom-dark-green/20 focus:outline-none placeholder:text-custom-dark-green/50" %>
@@ -36,7 +36,7 @@
         <%= f.hidden_field :postable_type, value: "DocumentPost" %>
         
         <div class="form-control">
-          <%= f.fields_for :postable_attributes, (post.postable&.document || Document.new) do |document_post_form| %>
+          <%= f.fields_for :postable_attributes, (post.postable.is_a?(DocumentPost) ? post.postable.document : Document.new) do |document_post_form| %>
             <%= document_post_form.label :url, "URL", class: "label text-custom-dark-green" %>
             <%= document_post_form.text_field :url, 
                 placeholder: "https://docs.example.com", 

--- a/app/views/posts/_form.html.erb
+++ b/app/views/posts/_form.html.erb
@@ -36,7 +36,7 @@
         <%= f.hidden_field :postable_type, value: "DocumentPost" %>
         
         <div class="form-control">
-          <%= f.fields_for :postable_attributes do |document_post_form| %>
+          <%= f.fields_for :postable_attributes, (post.postable&.document || Document.new) do |document_post_form| %>
             <%= document_post_form.label :url, "URL", class: "label text-custom-dark-green" %>
             <%= document_post_form.text_field :url, 
                 placeholder: "https://docs.example.com", 

--- a/app/views/shared/_inline_error_messages.html.erb
+++ b/app/views/shared/_inline_error_messages.html.erb
@@ -1,11 +1,24 @@
 <!-- 🎓 ぼっち演算子&.を使わないと`spec/system/posts_spec.rb`のテストが失敗するので注意 -->
 <!-- おそらく、object.postableがnilの場合、NoMethodErrorが発生するため。 -->
-<% if object.postable&.errors&.any? %>
+<% if object.errors.any? || object.postable&.errors&.any? %>
   <div class="text-sm text-custom-rust mt-1">
-    <% object.postable.errors.full_messages.each do |message| %>
-      <div class="flex items-center gap-1">
-        <span><%= message %></span>
-      </div>
+    <!-- object.postable(Postable)のエラー(TextPostの場合のみ表示) -->
+    <% if object.postable.is_a?(TextPost) %>
+      <% object.postable.errors.full_messages.each do |message| %>
+        <div class="flex items-center gap-1">
+          <span><%= message %></span>
+        </div>
+      <% end %>
+    
+    <!-- object(Post)自体のエラー（DocumentPostの場合のみ表示） -->
+    <!-- 🎓 DocumentPostの投稿が失敗した場合、object.postableはnilになるため、エラーメッセージを取得できない。 -->
+    <!-- そのため、Postsコントローラーでobjectにerrorsを追加し、この箇所でエラーを表示する。-->
+    <% elsif object.postable.is_a?(DocumentPost) %>
+      <% object.errors.full_messages.each do |message| %>
+        <div class="flex items-center gap-1">
+          <span><%= message %></span>
+        </div>
+      <% end %>
     <% end %>
   </div>
 <% end %>

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -28,6 +28,8 @@ ja:
         title: "タイトル"
         tag_ids: "タグ"
         status: "ステータス"
+      document:
+        url: "URL"
       # ネストした属性を日本語対応する場合、parent/childrenのように記述する。
       # 詳細は、https://nisshiee.hatenablog.jp/entry/2017/05/09/195115
       task/todos:
@@ -45,6 +47,8 @@ ja:
       invalid: "は無効な値です"
       taken: "はすでに登録済みです"
       confirmation: "と%{attribute}の入力が一致しません"
+      invalid_url_format: "は無効な形式です"
+      invalid_protocol: "はhttpまたはhttpsで始まる必要があります"
     attributes:
       tag_ids:
         too_many: "は最大5個まで選択できます"


### PR DESCRIPTION
## 概要
- DocumentモデルのURLカラムに正規表現のバリデーションを追加
- ドキュメント型ポストのバリデーションエラー時のエラーメッセージの実装
- 関連するモデルスペック・システムスペックの実装

## 変更点
### 1. DocumentモデルのURLカラムに正規表現のバリデーションを追加
- [x] urlのプロトコルはhttpとhttpsのみ許可

### 2. ドキュメント型ポストのエラーメッセージの実装
- [x] ポスト投稿失敗時にエラーメッセージを表示
- [x] エラーメッセージを日本語対応