### PR TITLE
デプロイ環境でGithub認証が失敗するバグを修正する

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -47,7 +47,9 @@ group :development, :test do
   gem "rspec-rails", "~> 8.0.0"
   gem "factory_bot_rails"
 
-  gem "dotenv-rails" # 環境変数の管理
+  # See https://github.com/bkeepers/dotenv
+  # 開発環境でのみ使用する環境変数を管理する、それ以外の環境変数はインフラ(Render)側で管理する
+  gem "dotenv-rails"
 end
 
 group :development do


### PR DESCRIPTION
## 概要
以下のIssueで提起したデプロイ環境でのバグを修正した。
- #259 

## 変更点
### 本番環境用のOAuth Appを作成
URL: https://github.com/settings/applications/3256781
- GitHub認証の環境変数の取得
- URL設定(home page, callback page)

### Renderで環境変数を設定
OAuth App 作成時に取得した環境変数をRender側で設定
<img width="2108" height="1490" alt="image" src="https://github.com/user-attachments/assets/76cec131-a97e-469c-87d1-1e467df3ba80" />
