### PR TITLE
feat: フッターにプライバシーポリシー/利用規約ページへのリンクを追加した

### DIFF
--- a/app/views/shared/_footer.html.erb
+++ b/app/views/shared/_footer.html.erb
@@ -2,6 +2,7 @@
   <nav class="grid grid-flow-col gap-4">
     <%= link_to "お問い合わせ", "https://forms.gle/mPrdREzhbRRauaZ27", class: "link link-hover link-neutral hover:text-neutral/80", target: "_blank", rel: "noopener noreferrer" %>
     <%= link_to "利用規約", "https://www.kiyac.app/termsOfService/4gR3qtrlqQcSLST3C8GR", class: "link link-hover link-neutral hover:text-neutral/80", target: "_blank", rel: "noopener noreferrer" %>
+    <%= link_to "プライバシーポリシー", "https://www.kiyac.app/privacypolicy/QroAe9nXkWPnsy1c9yuw", class: "link link-hover link-neutral hover:text-neutral/80", target: "_blank", rel: "noopener noreferrer" %>
   </nav>
   <aside>
     <p>Copyright © 2025 All right reserved by memoTIL</p>


### PR DESCRIPTION
## 概要
フッターにプライバシーポリシー/利用規約ページへのリンクを追加した

### 関連するissue
- #149 

## 主な変更点
- フッターにプライバシーポリシー/利用規約ページへのリンクを追加

### フッター
<img width="2856" height="328" alt="image" src="https://github.com/user-attachments/assets/012ea40d-e54e-4295-9f78-11852f72160b" />

### プライバシーポリシーページ
<img width="2866" height="1771" alt="image" src="https://github.com/user-attachments/assets/32154deb-54f8-4b44-861b-654ed2233b17" />

### 利用規約ページ
<img width="2842" height="1773" alt="image" src="https://github.com/user-attachments/assets/7bb69f88-b86a-4b7e-bcc5-0a7959301a3c" />
