### PR TITLE
fix: 本番環境でのGitHub認証済みユーザーがprivateリポジトリを参照できないバグを修正した

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -12,12 +12,19 @@ class User < ApplicationRecord
 
   def self.from_github(auth)
     # 👍 今後、メールアドレスなどでログインしている状態でタスク詳細画面からGitHub認証を行う場合、GitHubアカウントの情報を既存のUserレコードに追加する処理を実装予定。
-    find_or_create_by(github_uid: auth.uid) do |user|
-      user.email = auth.info.email
-      user.password = Devise.friendly_token[0, 20]
-      user.name = auth.info.name || auth.info.nickname
-      user.github_token = auth.credentials.token
+    user = find_or_create_by(github_uid: auth.uid) do |u|
+      u.email = auth.info.email
+      u.password = Devise.friendly_token[0, 20]
+      u.name = auth.info.name || auth.info.nickname
+      u.github_token = auth.credentials.token
     end
+
+    # 既存ユーザーの場合もトークンを更新する（スコープ変更に対応するため）
+    if user.persisted? && user.github_token != auth.credentials.token
+      user.update(github_token: auth.credentials.token)
+    end
+
+    user
   end
 
   def guest_user?


### PR DESCRIPTION
## 概要
本番環境ですでにGitHub連携しているユーザーがpublicリポジトリしか表示できないバグを修正した

### 関連するissue, PR
- #307 
- #289 
- #294

## 実装方針
- [x] GitHub認証メソッドにて、認証済みユーザーのトークンを更新する処理を追加する。