### PR TITLE
 ui: ポスト投稿フォームを投稿一覧の上に表示するように変更した

### DIFF
--- a/app/views/tasks/_posts_section.html.erb
+++ b/app/views/tasks/_posts_section.html.erb
@@ -1,5 +1,5 @@
 <!-- ポストセクション -->
-<div class="flex-1 flex flex-col justify-between w-full">
+<div class="flex-1 flex flex-col justify-between w-full gap-4">
   <!-- ポスト投稿フォーム -->
   <% if task.doing? %>
     <%= turbo_frame_tag "post_form" do %>


### PR DESCRIPTION
## 概要
Doingタスク詳細画面のポスト投稿フォームを投稿一覧の上に表示するように変更した。

### 関連するissue
- #330 

### 変更前のUI
<img width="2864" height="1209" alt="Image" src="https://github.com/user-attachments/assets/b60e66ca-ce61-4ec4-a13a-dcd808e582c6" />

### 変更後のUI
<img width="2872" height="1082" alt="image" src="https://github.com/user-attachments/assets/8d21db89-1caa-4b95-aeca-0259da641f13" />
