### PR TITLE
ui: トップ画面のUIや説明内容を修正した

### DIFF
--- a/app/views/static_pages/top.html.erb
+++ b/app/views/static_pages/top.html.erb
@@ -1,6 +1,6 @@
 <div class="flex justify-center items-center h-full w-full p-10 gap-6">
   <div class="flex flex-col items-center justify-center p-4 gap-6">
-    <%= image_tag "description.svg", class: "w-2/3" %>
+    <%= image_tag "description.svg", class: "w-4/5" %>
     <p class="text-lg font-bold text-custom-dark-green">学習や作業中の気づきをメモする<br>メモをまとめてTILとして記録する<br>学びを形にする学習・作業メモアプリ</p>
     <%= link_to "アプリを始める", tasks_path, class: "btn btn-lg btn-primary btn-outline rounded-full text-base" %>
   </div>


### PR DESCRIPTION
## 概要
トップ画面のUIや説明内容を修正した

### 関連するissue
- #304 

### 修正前のUI

<img width="2856" height="1032" alt="Image" src="https://github.com/user-attachments/assets/bc7bdfc4-15d6-4b0b-b672-10036e0a0dca" />

### 修正後のUI
<img width="2867" height="1380" alt="image" src="https://github.com/user-attachments/assets/1331c3ab-12bb-4fe6-9cbd-3cc6ffeef093" />
