### PR TITLE
bug-fix: 認証画面での送信時にバリデーションエラーが起きた時、非認証画面用のヘッダーが表示されるバグを修正する

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -2,9 +2,9 @@ module ApplicationHelper
   def auth_page?
     devise_controller? && (
       (controller_name == "sessions" && action_name == "new") ||
-      (controller_name == "registrations" && action_name == "new") ||
-      (controller_name == "passwords" && %w[new edit].include?(action_name)) ||
-      (controller_name == "confirmations" && %w[new show].include?(action_name))
+      (controller_name == "registrations" && %w[new create].include?(action_name)) ||
+      (controller_name == "passwords" && %w[new edit create update].include?(action_name)) ||
+      (controller_name == "confirmations" && %w[new show create].include?(action_name))
     )
   end
 end


### PR DESCRIPTION
## 概要
認証画面での送信時にバリデーションエラーが起きた時、非認証画面用のヘッダーが表示されるバグを修正する

### 関連するissue
- #355 

## 主な変更点
変更ファイル: `app/helpers/application_helper.rb`
auth_page?の各コントローラーのアクション判定にcreate, updateアクションを加えた