### PR TITLE
bug-fix: タスク詳細画面の画面更新時に、Todo項目の順番が入れ替わるバグを修正した

### DIFF
--- a/app/models/task.rb
+++ b/app/models/task.rb
@@ -3,7 +3,7 @@ class Task < ApplicationRecord
 
   has_many :tasktags, dependent: :destroy
   has_many :tags, through: :tasktags
-  has_many :todos, dependent: :destroy
+  has_many :todos, -> { order(created_at: :asc, id: :asc) }, dependent: :destroy
   has_many :posts, dependent: :destroy
 
   # 🎓 reject_if: :all_blank について、:all_blankが渡されると、_destroyの値を除くすべての属性が空白レコードを受け付けなくなるprocが1つ生成されます。


### PR DESCRIPTION
## 概要
Doingタスク詳細画面のTodoフォームにおいて、画面更新時にチェック済みTodoがリスト下部に移動するバグを修正する

### 関連するissue
- #347 

## 主な変更点
- Taksモデルにタスクに紐づくToDoを作成日時とidの昇順で取得するスコープを追加