### PR TITLE
ui: Doneタスク詳細画面のUIを修正した

### DIFF
--- a/app/views/tasks/show.html.erb
+++ b/app/views/tasks/show.html.erb
@@ -41,7 +41,7 @@
       <div class="divider divider-horizontal"></div>
 
       <!-- タスクのサブ情報サイドバー -->
-      <div class="flex flex-col items-start gap-1 max-w-sm w-full">
+      <div class="flex flex-col items-start gap-1 max-w-xl w-full">
         <%= render 'tasks/done_sidebar', task: @task %>
       </div>
     </div>


### PR DESCRIPTION
## 概要
Doneタスク詳細画面の右サイドバーの領域を広げ、TIL作成を行いやすくする

### 関連するissue
- #361 

## 主な変更点
- Doneタスク詳細画面の右サイドバーの領域を広げた

### 修正前のDoneタスク詳細画面
<img width="2872" height="1316" alt="Image" src="https://github.com/user-attachments/assets/0ca7be16-7c02-46b8-9038-982c33c6b2a3" />

### 修正後のDoneタスク詳細画面
<img width="2867" height="1610" alt="image" src="https://github.com/user-attachments/assets/163ff0bb-aea0-4f1c-88ee-e162f09aed46" />
