### PR TITLE
fix: タスク編集ボタンにテキストを追加

### DIFF
--- a/app/views/tasks/_task_content.html.erb
+++ b/app/views/tasks/_task_content.html.erb
@@ -3,10 +3,11 @@
     <!-- タイトル -->
     <p class="text-2xl font-bold text-custom-dark-green"><%= task.title %></p>
     <!-- 編集ボタン -->
-    <%= link_to edit_task_path(task), class: "btn btn-circle btn-ghost text-neutral border-none shadow-none hover:bg-neutral/10" do %>
+    <%= link_to edit_task_path(task), class: "btn btn-ghost text-neutral border-none shadow-none hover:bg-neutral/10 rounded-full" do %>
       <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round" class="size-6">
         <path stroke="none" d="M0 0h24v24H0z" fill="none"/><path d="M7 7h-1a2 2 0 0 0 -2 2v9a2 2 0 0 0 2 2h9a2 2 0 0 0 2 -2v-1" /><path d="M20.385 6.585a2.1 2.1 0 0 0 -2.97 -2.97l-8.415 8.385v3h3l8.385 -8.415z" /><path d="M16 5l3 3" />
       </svg>
+      <span>編集</span>
     <% end %>
   </div>
 


### PR DESCRIPTION
## 概要
タスク編集ボタンにテキストを追加し、アクセシビリティを向上

### 関連するissue
- #398 