### PR TITLE
フラッシュメッセージの表示位置・自動／手動クローズの改善

### DIFF
--- a/app/javascript/controllers/flash_message_controller.js
+++ b/app/javascript/controllers/flash_message_controller.js
@@ -1,0 +1,12 @@
+import { Controller } from "@hotwired/stimulus";
+
+export default class extends Controller {
+  dismiss(event) {
+    event.preventDefault();
+    const el = this.element;
+    el.classList.add("opacity-0", "pointer-events-none");
+    setTimeout(() => {
+      if (el.isConnected) el.remove();
+    }, 300);
+  }
+}

--- a/app/javascript/controllers/flash_message_controller.js
+++ b/app/javascript/controllers/flash_message_controller.js
@@ -1,12 +1,35 @@
 import { Controller } from "@hotwired/stimulus";
 
+const AUTO_HIDE_MS = 6000;
+const FADE_MS = 800;
+
 export default class extends Controller {
+  #autoHideTimer = 0;
+  #removeTimer = 0;
+
+  connect() {
+    this.#autoHideTimer = window.setTimeout(
+      () => this.#fadeOutAndRemove(),
+      AUTO_HIDE_MS,
+    );
+  }
+
+  disconnect() {
+    clearTimeout(this.#autoHideTimer);
+    clearTimeout(this.#removeTimer);
+  }
+
   dismiss(event) {
     event.preventDefault();
+    clearTimeout(this.#autoHideTimer);
+    this.#fadeOutAndRemove();
+  }
+
+  #fadeOutAndRemove() {
     const el = this.element;
     el.classList.add("opacity-0", "pointer-events-none");
-    setTimeout(() => {
+    this.#removeTimer = window.setTimeout(() => {
       if (el.isConnected) el.remove();
-    }, 300);
+    }, FADE_MS);
   }
 }

--- a/app/javascript/controllers/index.js
+++ b/app/javascript/controllers/index.js
@@ -24,3 +24,6 @@ application.register("todo-section", TodoSectionController);
 
 import DescriptionExpandController from "./description_expand_controller";
 application.register("description-expand", DescriptionExpandController);
+
+import FlashMessageController from "./flash_message_controller";
+application.register("flash-message", FlashMessageController);

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -90,7 +90,7 @@
     <% end %>
     
     <div class="bg-base-100 rounded-lg min-h-screen">
-      <main class="text-base-content">
+      <main class="relative text-base-content">
         <%= render 'shared/flash_messages' %>
         <%= yield %>
       </main>

--- a/app/views/shared/_flash_messages.html.erb
+++ b/app/views/shared/_flash_messages.html.erb
@@ -12,8 +12,11 @@
           <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 12l2 2 4-4m6 2a9 9 0 11-18 0 9 9 0 0118 0z" />
         </svg>
         <span class="flex-1 min-w-0 break-words"><%= flash[:notice] %></span>
-        <button type="button" class="btn btn-sm btn-circle btn-ghost shrink-0"
-                data-action="click->flash-message#dismiss">
+        <button
+          type="button"
+          class="btn btn-sm btn-circle shrink-0 border-0 !bg-transparent text-current shadow-none transition-colors hover:!bg-dark-green/15"
+          data-action="click->flash-message#dismiss"
+        >
           <svg xmlns="http://www.w3.org/2000/svg" class="h-5 w-5" fill="none" viewBox="0 0 24 24" stroke="currentColor" aria-hidden="true">
             <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M6 18L18 6M6 6l12 12" />
           </svg>
@@ -37,8 +40,11 @@
             <%= flash[:alert] %>
           <% end %>
         </span>
-        <button type="button" class="btn btn-sm btn-circle btn-ghost shrink-0"
-                data-action="click->flash-message#dismiss">
+        <button
+          type="button"
+          class="btn btn-sm btn-circle shrink-0 border-0 !bg-transparent text-current shadow-none transition-colors hover:!bg-red/15"
+          data-action="click->flash-message#dismiss"
+        >
           <svg xmlns="http://www.w3.org/2000/svg" class="h-5 w-5" fill="none" viewBox="0 0 24 24" stroke="currentColor" aria-hidden="true">
             <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M6 18L18 6M6 6l12 12" />
           </svg>

--- a/app/views/shared/_flash_messages.html.erb
+++ b/app/views/shared/_flash_messages.html.erb
@@ -4,7 +4,7 @@
     <% if flash[:notice].present? %>
       <%# daisyUI .alert は sm 以上で 2 列 grid のため、閉じるボタンが 3 つ目だと崩れる。flex で上書きする %>
       <div
-        class="alert alert-success alert-soft shadow-md !flex !flex-row !items-center !gap-3 !text-left !justify-start w-full transition-opacity duration-200"
+        class="alert alert-success alert-soft shadow-md !flex !flex-row !items-center !gap-3 !text-left !justify-start w-full transition-opacity duration-500"
         data-controller="flash-message"
         role="status"
       >
@@ -22,7 +22,7 @@
     <% end %>
     <% if flash[:alert].present? %>
       <div
-        class="alert alert-error alert-soft shadow-md !flex !flex-row !items-center !gap-3 !text-left !justify-start w-full transition-opacity duration-200"
+        class="alert alert-error alert-soft shadow-md !flex !flex-row !items-center !gap-3 !text-left !justify-start w-full transition-opacity duration-500"
         data-controller="flash-message"
         role="alert"
       >

--- a/app/views/shared/_flash_messages.html.erb
+++ b/app/views/shared/_flash_messages.html.erb
@@ -1,24 +1,39 @@
-<% if flash[:notice] %>
-  <div class="alert alert-success alert-soft mx-4 mt-4">
-    <svg xmlns="http://www.w3.org/2000/svg" class="stroke-current shrink-0 h-6 w-6" fill="none" viewBox="0 0 24 24">
-      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 12l2 2 4-4m6 2a9 9 0 11-18 0 9 9 0 0118 0z" />
-    </svg>
-    <span><%= flash[:notice] %></span>
+<% if flash[:notice].present? || flash[:alert].present? %>
+  <%# daisyUI の .toast は position:fixed でビューポート基準になるため使わず、main 内の右上に absolute 配置する %>
+  <div class="absolute top-4 right-4 z-50 flex flex-col gap-2 max-w-md w-[min(100%,28rem)] sm:max-w-lg">
+    <% if flash[:notice].present? %>
+      <%# daisyUI .alert は sm 以上で 2 列 grid のため、閉じるボタンが 3 つ目だと崩れる。flex で上書きする %>
+      <div class="alert alert-success alert-soft shadow-md !flex !flex-row !items-center !gap-3 !text-left !justify-start w-full" role="status" aria-live="polite">
+        <svg xmlns="http://www.w3.org/2000/svg" class="stroke-current shrink-0 h-6 w-6" fill="none" viewBox="0 0 24 24" aria-hidden="true">
+          <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 12l2 2 4-4m6 2a9 9 0 11-18 0 9 9 0 0118 0z" />
+        </svg>
+        <span class="flex-1 min-w-0 break-words"><%= flash[:notice] %></span>
+        <button type="button" class="btn btn-sm btn-circle btn-ghost shrink-0">
+          <svg xmlns="http://www.w3.org/2000/svg" class="h-5 w-5" fill="none" viewBox="0 0 24 24" stroke="currentColor" aria-hidden="true">
+            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M6 18L18 6M6 6l12 12" />
+          </svg>
+        </button>
+      </div>
+    <% end %>
+    <% if flash[:alert].present? %>
+      <div class="alert alert-error alert-soft shadow-md !flex !flex-row !items-center !gap-3 !text-left !justify-start w-full" role="alert" aria-live="assertive">
+        <svg xmlns="http://www.w3.org/2000/svg" class="stroke-current shrink-0 h-6 w-6" fill="none" viewBox="0 0 24 24" aria-hidden="true">
+          <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M10 14l2-2m0 0l2-2m-2 2l-2-2m2 2l2 2m7-2a9 9 0 11-18 0 9 9 0 0118 0z" />
+        </svg>
+        <span class="flex-1 min-w-0 break-words">
+          <% if flash[:alert] == I18n.t("devise.failure.user.unconfirmed") %>
+            <%# 未確認のメールアドレスでログインしようとした場合のみ、リンク付きメッセージを表示 %>
+            メールアドレスの確認が完了していません（確認メールが見つからない方は<%= link_to "こちら", new_user_confirmation_path, class: "link link-error font-semibold" %>から新しいメールを再送信してください）
+          <% else %>
+            <%= flash[:alert] %>
+          <% end %>
+        </span>
+        <button type="button" class="btn btn-sm btn-circle btn-ghost shrink-0">
+          <svg xmlns="http://www.w3.org/2000/svg" class="h-5 w-5" fill="none" viewBox="0 0 24 24" stroke="currentColor" aria-hidden="true">
+            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M6 18L18 6M6 6l12 12" />
+          </svg>
+        </button>
+      </div>
+    <% end %>
   </div>
 <% end %>
-<% if flash[:alert] %>
-  <div class="alert alert-error alert-soft mx-4 mt-4">
-    <svg xmlns="http://www.w3.org/2000/svg" class="stroke-current shrink-0 h-6 w-6" fill="none" viewBox="0 0 24 24">
-      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M10 14l2-2m0 0l2-2m-2 2l-2-2m2 2l2 2m7-2a9 9 0 11-18 0 9 9 0 0118 0z" />
-    </svg>
-    <span>
-      <% if flash[:alert] == I18n.t("devise.failure.user.unconfirmed") %>
-        <!-- 未確認のメールアドレスでログインしようとした場合のみ、リンク付きメッセージを表示 -->
-        メールアドレスの確認が完了していません（確認メールが見つからない方は<%= link_to "こちら", new_user_confirmation_path, class: "link link-error font-semibold" %>から新しいメールを再送信してください）
-      <% else %>
-        <%= flash[:alert] %>
-      <% end %>
-    </span>
-  </div>
-<% end %>
-

--- a/app/views/shared/_flash_messages.html.erb
+++ b/app/views/shared/_flash_messages.html.erb
@@ -3,12 +3,17 @@
   <div class="absolute top-4 right-4 z-50 flex flex-col gap-2 max-w-md w-[min(100%,28rem)] sm:max-w-lg">
     <% if flash[:notice].present? %>
       <%# daisyUI .alert は sm 以上で 2 列 grid のため、閉じるボタンが 3 つ目だと崩れる。flex で上書きする %>
-      <div class="alert alert-success alert-soft shadow-md !flex !flex-row !items-center !gap-3 !text-left !justify-start w-full" role="status" aria-live="polite">
+      <div
+        class="alert alert-success alert-soft shadow-md !flex !flex-row !items-center !gap-3 !text-left !justify-start w-full transition-opacity duration-200"
+        data-controller="flash-message"
+        role="status"
+      >
         <svg xmlns="http://www.w3.org/2000/svg" class="stroke-current shrink-0 h-6 w-6" fill="none" viewBox="0 0 24 24" aria-hidden="true">
           <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 12l2 2 4-4m6 2a9 9 0 11-18 0 9 9 0 0118 0z" />
         </svg>
         <span class="flex-1 min-w-0 break-words"><%= flash[:notice] %></span>
-        <button type="button" class="btn btn-sm btn-circle btn-ghost shrink-0">
+        <button type="button" class="btn btn-sm btn-circle btn-ghost shrink-0"
+                data-action="click->flash-message#dismiss">
           <svg xmlns="http://www.w3.org/2000/svg" class="h-5 w-5" fill="none" viewBox="0 0 24 24" stroke="currentColor" aria-hidden="true">
             <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M6 18L18 6M6 6l12 12" />
           </svg>
@@ -16,7 +21,11 @@
       </div>
     <% end %>
     <% if flash[:alert].present? %>
-      <div class="alert alert-error alert-soft shadow-md !flex !flex-row !items-center !gap-3 !text-left !justify-start w-full" role="alert" aria-live="assertive">
+      <div
+        class="alert alert-error alert-soft shadow-md !flex !flex-row !items-center !gap-3 !text-left !justify-start w-full transition-opacity duration-200"
+        data-controller="flash-message"
+        role="alert"
+      >
         <svg xmlns="http://www.w3.org/2000/svg" class="stroke-current shrink-0 h-6 w-6" fill="none" viewBox="0 0 24 24" aria-hidden="true">
           <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M10 14l2-2m0 0l2-2m-2 2l-2-2m2 2l2 2m7-2a9 9 0 11-18 0 9 9 0 0118 0z" />
         </svg>
@@ -28,7 +37,8 @@
             <%= flash[:alert] %>
           <% end %>
         </span>
-        <button type="button" class="btn btn-sm btn-circle btn-ghost shrink-0">
+        <button type="button" class="btn btn-sm btn-circle btn-ghost shrink-0"
+                data-action="click->flash-message#dismiss">
           <svg xmlns="http://www.w3.org/2000/svg" class="h-5 w-5" fill="none" viewBox="0 0 24 24" stroke="currentColor" aria-hidden="true">
             <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M6 18L18 6M6 6l12 12" />
           </svg>


### PR DESCRIPTION
## 概要
フラッシュメッセージを main 内の右上（ヘッダー上ではなく）に表示し、フェードアウト後に、閉じるボタンまたは6秒後にDOMから削除するように実装。
また、Stimulus の flash-message コントローラを導入。

### 関連Issue
#397

## 主な変更点
- main に relative を付与し、フラッシュメッセージのラッパーを absolute 配置に変更（daisyUI の viewport 固定 .toast は使用しない）
- daisyUI の alert に対して Flex レイアウトを上書きし、アイコン・テキスト・3つ目の要素（閉じるボタン）を調整
- flash_message_controller.js を実装
  - 手動での閉じる処理
  - 自動非表示タイマー
  - disconnect 時のクリーンアップ
- 閉じるボタンのスタイル調整
  - btn btn-sm btn-circle
   - !bg-transparent
  - hover:!bg-dark-green/15
- transition-opacity duration-500 をコントローラのフェード遅延と整合させた