### PR TITLE
タスク詳細のチャット出力切り替えをtoggle化し送信UXを改善

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -7,4 +7,22 @@ module ApplicationHelper
       (controller_name == "confirmations" && %w[new show create].include?(action_name))
     )
   end
+
+  def text_post_icon
+    content_tag(:svg, xmlns: "http://www.w3.org/2000/svg", fill: "none", viewBox: "0 0 24 24", "stroke-width": "1.5", stroke: "currentColor") do
+      tag.path("stroke-linecap": "round", "stroke-linejoin": "round", d: "M7.5 8.25h9m-9 3H12m-9.75 1.51c0 1.6 1.123 2.994 2.707 3.227 1.129.166 2.27.293 3.423.379.35.026.67.21.865.501L12 21l2.755-4.133a1.14 1.14 0 0 1 .865-.501 48.172 48.172 0 0 0 3.423-.379c1.584-.233 2.707-1.626 2.707-3.228V6.741c0-1.602-1.123-2.995-2.707-3.228A48.394 48.394 0 0 0 12 3c-2.392 0-4.744.175-7.043.513C3.373 3.746 2.25 5.14 2.25 6.741v6.018Z")
+    end
+  end
+
+  def document_post_icon
+    content_tag(:svg, xmlns: "http://www.w3.org/2000/svg", fill: "none", viewBox: "0 0 24 24", "stroke-width": "1.5", stroke: "currentColor") do
+      tag.path("stroke-linecap": "round", "stroke-linejoin": "round", d: "M19.5 14.25v-2.625a3.375 3.375 0 0 0-3.375-3.375h-1.5A1.125 1.125 0 0 1 13.5 7.125v-1.5a3.375 3.375 0 0 0-3.375-3.375H8.25m0 12.75h7.5m-7.5 3H12M10.5 2.25H5.625c-.621 0-1.125.504-1.125 1.125v17.25c0 .621.504 1.125 1.125 1.125h12.75c.621 0 1.125-.504 1.125-1.125V11.25a9 9 0 0 0-9-9Z")
+    end
+  end
+
+  def send_post_icon(css_class: "size-4")
+    content_tag(:svg, xmlns: "http://www.w3.org/2000/svg", fill: "none", viewBox: "0 0 24 24", "stroke-width": "1.5", stroke: "currentColor", class: css_class) do
+      tag.path("stroke-linecap": "round", "stroke-linejoin": "round", d: "M6 12 3.269 3.125A59.769 59.769 0 0 1 21.485 12 59.768 59.768 0 0 1 3.27 20.875L5.999 12Zm0 0h7.5")
+    end
+  end
 end

--- a/app/javascript/controllers/index.js
+++ b/app/javascript/controllers/index.js
@@ -27,3 +27,6 @@ application.register("description-expand", DescriptionExpandController);
 
 import FlashMessageController from "./flash_message_controller";
 application.register("flash-message", FlashMessageController);
+
+import PostFormToggleController from "./post_form_toggle_controller";
+application.register("post-form-toggle", PostFormToggleController);

--- a/app/javascript/controllers/post_form_toggle_controller.js
+++ b/app/javascript/controllers/post_form_toggle_controller.js
@@ -1,7 +1,7 @@
 import { Controller } from "@hotwired/stimulus";
 
 export default class extends Controller {
-  static targets = ["textForm", "documentForm", "toggle"];
+  static targets = ["textForm", "documentForm", "toggle", "textarea"];
   static values = { initialType: String };
 
   connect() {
@@ -9,6 +9,7 @@ export default class extends Controller {
     // 以降、isDocumentはToggleのchecked状態と同期する
     const isDocument = this.initialTypeValue === "DocumentPost";
     this.render(isDocument);
+    this.resizeAllTextareas();
   }
 
   toggle(event) {
@@ -22,6 +23,11 @@ export default class extends Controller {
     event.currentTarget.form?.requestSubmit();
   }
 
+  // フォーム入力時にtextareaの高さを自動調整
+  autoResize(event) {
+    this.resizeTextarea(event.currentTarget);
+  }
+
   render(isDocument) {
     // 2つのフォームの表示/非表示を切り替え
     this.textFormTarget.classList.toggle("hidden", isDocument);
@@ -31,5 +37,18 @@ export default class extends Controller {
     this.toggleTargets.forEach((toggle) => {
       toggle.checked = isDocument;
     });
+  }
+
+  // すべてのtextareaの高さを自動調整
+  resizeAllTextareas() {
+    this.textareaTargets.forEach((textarea) => {
+      this.resizeTextarea(textarea);
+    });
+  }
+
+  // textareaの高さをscrollHeightに合わせて自動調整
+  resizeTextarea(textarea) {
+    textarea.style.height = "auto";
+    textarea.style.height = `${textarea.scrollHeight}px`;
   }
 }

--- a/app/javascript/controllers/post_form_toggle_controller.js
+++ b/app/javascript/controllers/post_form_toggle_controller.js
@@ -1,7 +1,15 @@
 import { Controller } from "@hotwired/stimulus";
 
 export default class extends Controller {
-  static targets = ["textForm", "documentForm", "toggle", "textarea"];
+  static targets = [
+    "textForm",
+    "documentForm",
+    "toggle",
+    "textarea",
+    "textInput",
+    "documentInput",
+    "postableType",
+  ];
   static values = { initialType: String };
 
   connect() {
@@ -29,11 +37,18 @@ export default class extends Controller {
   }
 
   render(isDocument) {
-    // 2つのフォームの表示/非表示を切り替え
+    // 表示中のフォームパネルを切り替える
     this.textFormTarget.classList.toggle("hidden", isDocument);
     this.documentFormTarget.classList.toggle("hidden", !isDocument);
 
-    // 2つのフォームのトグルのchecked状態を更新
+    // hidden field の postable_type を更新
+    this.postableTypeTarget.value = isDocument ? "DocumentPost" : "TextPost";
+
+    // 非表示側の入力は送信対象から外す
+    this.textInputTarget.disabled = isDocument;
+    this.documentInputTarget.disabled = !isDocument;
+
+    // トグルUIの見た目を同期
     this.toggleTargets.forEach((toggle) => {
       toggle.checked = isDocument;
     });

--- a/app/javascript/controllers/post_form_toggle_controller.js
+++ b/app/javascript/controllers/post_form_toggle_controller.js
@@ -15,6 +15,13 @@ export default class extends Controller {
     this.render(event.currentTarget.checked);
   }
 
+  submitOnEnter(event) {
+    if (event.key !== "Enter" || event.shiftKey || event.isComposing) return;
+
+    event.preventDefault();
+    event.currentTarget.form?.requestSubmit();
+  }
+
   render(isDocument) {
     // 2つのフォームの表示/非表示を切り替え
     this.textFormTarget.classList.toggle("hidden", isDocument);

--- a/app/javascript/controllers/post_form_toggle_controller.js
+++ b/app/javascript/controllers/post_form_toggle_controller.js
@@ -1,0 +1,28 @@
+import { Controller } from "@hotwired/stimulus";
+
+export default class extends Controller {
+  static targets = ["textForm", "documentForm", "toggle"];
+  static values = { initialType: String };
+
+  connect() {
+    // ポストフォームの初期状態が"DocumentPost"の場合、isDocumentをtrueに設定
+    // 以降、isDocumentはToggleのchecked状態と同期する
+    const isDocument = this.initialTypeValue === "DocumentPost";
+    this.render(isDocument);
+  }
+
+  toggle(event) {
+    this.render(event.currentTarget.checked);
+  }
+
+  render(isDocument) {
+    // 2つのフォームの表示/非表示を切り替え
+    this.textFormTarget.classList.toggle("hidden", isDocument);
+    this.documentFormTarget.classList.toggle("hidden", !isDocument);
+
+    // 2つのフォームのトグルのchecked状態を更新
+    this.toggleTargets.forEach((toggle) => {
+      toggle.checked = isDocument;
+    });
+  }
+}

--- a/app/javascript/controllers/post_form_toggle_controller.js
+++ b/app/javascript/controllers/post_form_toggle_controller.js
@@ -37,6 +37,15 @@ export default class extends Controller {
     this.toggleTargets.forEach((toggle) => {
       toggle.checked = isDocument;
     });
+
+    // フォーム切り替え後に表示中フォームのtextarea高さを再計算
+    // requestAnimationFrame: DOM更新が反映された直後のフレームでコールバックを実行する
+    requestAnimationFrame(() => {
+      const visibleTextareas = this.textareaTargets.filter(
+        (textarea) => !textarea.closest(".hidden"),
+      );
+      visibleTextareas.forEach((textarea) => this.resizeTextarea(textarea));
+    });
   }
 
   // すべてのtextareaの高さを自動調整

--- a/app/views/posts/_document_post_form.html.erb
+++ b/app/views/posts/_document_post_form.html.erb
@@ -3,7 +3,7 @@
   <%= document_post_form.text_area :url,
       placeholder: placeholder_text.chomp,
       disabled: active_postable_type == "TextPost",
-      class: "textarea textarea-ghost w-full text-base-content placeholder:text-placeholder focus:outline-none",
+      class: "textarea textarea-ghost text-base w-full text-base-content placeholder:text-placeholder focus:outline-none",
       autocomplete: "off",
       data: {
         post_form_toggle_target: "textarea documentInput",

--- a/app/views/posts/_document_post_form.html.erb
+++ b/app/views/posts/_document_post_form.html.erb
@@ -3,14 +3,24 @@
   
   <%= f.fields_for :postable_attributes, (post.postable.is_a?(DocumentPost) ? post.postable.document : Document.new) do |document_post_form| %>
     <% placeholder_text = "参考にした資料のURLを入力しましょう(ex. https://railsguides.jp/)" %>
-    <%= document_post_form.text_field :url, 
+    <%= document_post_form.text_area :url, 
         placeholder: placeholder_text.chomp, 
-        class: "input input-ghost w-full text-base-content placeholder:text-placeholder focus:outline-none",
+        class: "textarea textarea-ghost h-32 w-full text-base-content placeholder:text-placeholder focus:outline-none",
         autocomplete: "off" %>
   <% end %>
   
-  <div class="flex justify-end gap-4">
-    <%= f.submit "送信", class: "btn btn-neutral rounded-full shadow-none" %>
+  <div class="flex items-center justify-between gap-4 px-2">
+    <label class="toggle toggle-lg text-base-content">
+      <input type="checkbox"
+             data-post-form-toggle-target="toggle"
+             data-action="change->post-form-toggle#toggle" />
+      <%= text_post_icon %>
+      <%= document_post_icon %>
+    </label>
+
+    <button type="submit" class="btn btn-neutral btn-sm btn-circle shadow-none" data-test-id="submit-post-button" aria-label="送信">
+      <%= send_post_icon %>
+    </button>
   </div>
 <% end %>
 

--- a/app/views/posts/_document_post_form.html.erb
+++ b/app/views/posts/_document_post_form.html.erb
@@ -1,30 +1,13 @@
-<%= form_with model: post, url: task_posts_path(task), method: :post, class: "flex flex-col gap-1", id: "document-post-form" do |f| %>
-  <%= f.hidden_field :postable_type, value: "DocumentPost" %>
-  
-  <%= f.fields_for :postable_attributes, (post.postable.is_a?(DocumentPost) ? post.postable.document : Document.new) do |document_post_form| %>
-    <% placeholder_text = "参考にした資料のURLを入力しましょう(ex. https://railsguides.jp/)" %>
-    <%= document_post_form.text_area :url, 
-        placeholder: placeholder_text.chomp, 
-        class: "textarea textarea-ghost w-full text-base-content placeholder:text-placeholder focus:outline-none",
-        autocomplete: "off",
-        data: {
-          post_form_toggle_target: "textarea",
-          action: "input->post-form-toggle#autoResize"
-        } %>
-  <% end %>
-  
-  <div class="flex items-center justify-between gap-4 px-2">
-    <label class="toggle toggle-lg text-base-content">
-      <input type="checkbox"
-             data-post-form-toggle-target="toggle"
-             data-action="change->post-form-toggle#toggle" />
-      <%= text_post_icon %>
-      <%= document_post_icon %>
-    </label>
-
-    <button type="submit" class="btn btn-neutral btn-sm btn-circle shadow-none" data-test-id="submit-post-button" aria-label="送信">
-      <%= send_post_icon %>
-    </button>
-  </div>
+<%= form.fields_for :postable_attributes, (post.postable.is_a?(DocumentPost) ? post.postable.document : Document.new) do |document_post_form| %>
+  <% placeholder_text = "参考にした資料のURLを入力しましょう(ex. https://railsguides.jp/)" %>
+  <%= document_post_form.text_area :url,
+      placeholder: placeholder_text.chomp,
+      disabled: active_postable_type == "TextPost",
+      class: "textarea textarea-ghost w-full text-base-content placeholder:text-placeholder focus:outline-none",
+      autocomplete: "off",
+      data: {
+        post_form_toggle_target: "textarea documentInput",
+        action: "input->post-form-toggle#autoResize"
+      } %>
 <% end %>
 

--- a/app/views/posts/_document_post_form.html.erb
+++ b/app/views/posts/_document_post_form.html.erb
@@ -7,7 +7,7 @@
       autocomplete: "off",
       data: {
         post_form_toggle_target: "textarea documentInput",
-        action: "input->post-form-toggle#autoResize"
+        action: "input->post-form-toggle#autoResize keydown->post-form-toggle#submitOnEnter"
       } %>
 <% end %>
 

--- a/app/views/posts/_document_post_form.html.erb
+++ b/app/views/posts/_document_post_form.html.erb
@@ -5,8 +5,12 @@
     <% placeholder_text = "参考にした資料のURLを入力しましょう(ex. https://railsguides.jp/)" %>
     <%= document_post_form.text_area :url, 
         placeholder: placeholder_text.chomp, 
-        class: "textarea textarea-ghost h-32 w-full text-base-content placeholder:text-placeholder focus:outline-none",
-        autocomplete: "off" %>
+        class: "textarea textarea-ghost w-full text-base-content placeholder:text-placeholder focus:outline-none",
+        autocomplete: "off",
+        data: {
+          post_form_toggle_target: "textarea",
+          action: "input->post-form-toggle#autoResize"
+        } %>
   <% end %>
   
   <div class="flex items-center justify-between gap-4 px-2">

--- a/app/views/posts/_form.html.erb
+++ b/app/views/posts/_form.html.erb
@@ -1,37 +1,18 @@
-<!-- ポスト投稿フォーム（TextPost投稿フォームとDocumentPost投稿フォームをタブ切り替え） -->
-<div role="tablist" class="tabs tabs-box bg-surface-elevated border border-subtle">
-  
-  <!-- TextPost タブ -->
-  <input type="radio" 
-         name="post_type" 
-         role="tab" 
-         class="tab text-base-content"
-         aria-label="メモ" 
-         <%= 'checked' if post.postable_type.blank? || post.postable_type == 'TextPost' %> />
-  <div role="tabpanel" class="tab-content bg-surface rounded-box p-1">
-    <!-- TextPost エラーメッセージ -->
-    <% if post.postable_type.blank? || post.postable_type == 'TextPost' %>
-      <%= render 'posts/post_error_messages', post: post %>
+<% active_postable_type = post.postable_type.presence || "TextPost" %>
+<div class="rounded-2xl border border-subtle bg-surface p-3"
+     data-controller="post-form-toggle"
+     data-post-form-toggle-initial-type-value="<%= active_postable_type %>">
+  <div data-post-form-toggle-target="textForm" class="<%= "hidden" if active_postable_type == "DocumentPost" %>">
+    <% if active_postable_type == "TextPost" %>
+      <%= render "posts/post_error_messages", post: post %>
     <% end %>
-    
-    <!-- TextPost フォーム -->
-    <%= render 'posts/text_post_form', post: post, task: task %>
+    <%= render "posts/text_post_form", post: post, task: task %>
   </div>
 
-  <!-- DocumentPost タブ -->
-  <input type="radio" 
-         name="post_type" 
-         role="tab" 
-         class="tab text-base-content"
-         aria-label="参照URL" 
-         <%= 'checked' if post.postable_type == 'DocumentPost' %> />
-  <div role="tabpanel" class="tab-content bg-surface rounded-box p-1">
-    <!-- DocumentPost エラーメッセージ -->
-    <% if post.postable_type == 'DocumentPost' %>
-      <%= render 'posts/post_error_messages', post: post %>
+  <div data-post-form-toggle-target="documentForm" class="<%= "hidden" unless active_postable_type == "DocumentPost" %>">
+    <% if active_postable_type == "DocumentPost" %>
+      <%= render "posts/post_error_messages", post: post %>
     <% end %>
-    
-    <!-- DocumentPost フォーム -->
-    <%= render 'posts/document_post_form', post: post, task: task %>
+    <%= render "posts/document_post_form", post: post, task: task %>
   </div>
 </div>

--- a/app/views/posts/_form.html.erb
+++ b/app/views/posts/_form.html.erb
@@ -2,17 +2,36 @@
 <div class="rounded-2xl border border-subtle bg-surface p-3"
      data-controller="post-form-toggle"
      data-post-form-toggle-initial-type-value="<%= active_postable_type %>">
-  <div data-post-form-toggle-target="textForm" class="<%= "hidden" if active_postable_type == "DocumentPost" %>">
-    <% if active_postable_type == "TextPost" %>
-      <%= render "posts/post_error_messages", post: post %>
-    <% end %>
-    <%= render "posts/text_post_form", post: post, task: task %>
-  </div>
+  <%= form_with model: post, url: task_posts_path(task), method: :post, class: "flex flex-col gap-1", id: "post-form" do |f| %>
+    <%= f.hidden_field :postable_type,
+        value: active_postable_type,
+        data: { post_form_toggle_target: "postableType" } %>
 
-  <div data-post-form-toggle-target="documentForm" class="<%= "hidden" unless active_postable_type == "DocumentPost" %>">
-    <% if active_postable_type == "DocumentPost" %>
+    <% if post.errors.any? %>
       <%= render "posts/post_error_messages", post: post %>
     <% end %>
-    <%= render "posts/document_post_form", post: post, task: task %>
-  </div>
+
+    <div data-post-form-toggle-target="textForm" class="<%= "hidden" if active_postable_type == "DocumentPost" %>">
+      <%= render "posts/text_post_form", form: f, post: post, active_postable_type: active_postable_type %>
+    </div>
+
+    <div data-post-form-toggle-target="documentForm" class="<%= "hidden" unless active_postable_type == "DocumentPost" %>">
+      <%= render "posts/document_post_form", form: f, post: post, active_postable_type: active_postable_type %>
+    </div>
+
+    <div class="flex items-center justify-between gap-4 px-2">
+      <label class="toggle toggle-lg text-base-content [--animation-input:0.35s] ease-in-out">
+        <input type="checkbox"
+               data-post-form-toggle-target="toggle"
+               data-action="change->post-form-toggle#toggle"
+               <%= "checked" if active_postable_type == "DocumentPost" %> />
+        <%= text_post_icon %>
+        <%= document_post_icon %>
+      </label>
+
+      <button type="submit" class="btn btn-neutral btn-sm btn-circle shadow-none" data-test-id="submit-post-button" aria-label="送信">
+        <%= send_post_icon %>
+      </button>
+    </div>
+  <% end %>
 </div>

--- a/app/views/posts/_post_error_messages.html.erb
+++ b/app/views/posts/_post_error_messages.html.erb
@@ -1,7 +1,7 @@
 <!-- 🎓 ぼっち演算子&.を使わないと`spec/system/posts_spec.rb`のテストが失敗するので注意 -->
 <!-- おそらく、post.postableがnilの場合、NoMethodErrorが発生するため。 -->
 <% if post.errors.any? || post.postable&.errors&.any? %>
-  <div class="text-sm text-error mt-1">
+  <div class="text-sm text-error mt-1 px-2">
     <!-- post.postable(Postable)のエラー(TextPostの場合のみ表示) -->
     <% if post.postable.is_a?(TextPost) %>
       <% post.postable.errors.full_messages.each do |message| %>

--- a/app/views/posts/_text_post_form.html.erb
+++ b/app/views/posts/_text_post_form.html.erb
@@ -13,11 +13,22 @@
     <%= text_post_form.text_area :body,
         autocomplete: "off",
         placeholder: placeholder_text.chomp,
-        class: "textarea textarea-ghost w-full h-32 text-base-content placeholder:text-placeholder focus:outline-none" %>
+        class: "textarea textarea-ghost w-full h-32 text-base-content placeholder:text-placeholder focus:outline-none",
+        data: { action: "keydown->post-form-toggle#submitOnEnter" } %>
   <% end %>
   
-  <div class="flex justify-end gap-4">
-    <%= f.submit "送信", class: "btn btn-neutral rounded-full shadow-none" %>
+  <div class="flex items-center justify-between gap-4 px-2">
+    <label class="toggle toggle-lg text-base-content">
+      <input type="checkbox"
+             data-post-form-toggle-target="toggle"
+             data-action="change->post-form-toggle#toggle" />
+      <%= text_post_icon %>
+      <%= document_post_icon %>
+    </label>
+
+    <button type="submit" class="btn btn-neutral btn-sm btn-circle shadow-none" data-test-id="submit-post-button" aria-label="送信">
+      <%= send_post_icon %>
+    </button>
   </div>
 <% end %>
 

--- a/app/views/posts/_text_post_form.html.erb
+++ b/app/views/posts/_text_post_form.html.erb
@@ -1,31 +1,13 @@
-<%= form_with model: post, url: task_posts_path(task), method: :post, class: "flex flex-col gap-1", id: "text-post-form" do |f| %>
-  <%= f.hidden_field :postable_type, value: "TextPost" %>
-  
-  <%= f.fields_for :postable_attributes, (post.postable.is_a?(TextPost) ? post.postable : TextPost.new) do |text_post_form| %>
-    <% placeholder_text = "調べたことや思いついたことを書きましょう"
-    %>
-    <%= text_post_form.text_area :body,
-        autocomplete: "off",
-        placeholder: placeholder_text.chomp,
-        class: "textarea textarea-ghost w-full text-base-content placeholder:text-placeholder focus:outline-none",
-        data: {
-          post_form_toggle_target: "textarea",
-          action: "input->post-form-toggle#autoResize keydown->post-form-toggle#submitOnEnter"
-        } %>
-  <% end %>
-  
-  <div class="flex items-center justify-between gap-4 px-2">
-    <label class="toggle toggle-lg text-base-content">
-      <input type="checkbox"
-             data-post-form-toggle-target="toggle"
-             data-action="change->post-form-toggle#toggle" />
-      <%= text_post_icon %>
-      <%= document_post_icon %>
-    </label>
-
-    <button type="submit" class="btn btn-neutral btn-sm btn-circle shadow-none" data-test-id="submit-post-button" aria-label="送信">
-      <%= send_post_icon %>
-    </button>
-  </div>
+<%= form.fields_for :postable_attributes, (post.postable.is_a?(TextPost) ? post.postable : TextPost.new) do |text_post_form| %>
+  <% placeholder_text = "調べたことや思いついたことを書きましょう" %>
+  <%= text_post_form.text_area :body,
+      autocomplete: "off",
+      placeholder: placeholder_text.chomp,
+      disabled: active_postable_type == "DocumentPost",
+      class: "textarea textarea-ghost w-full text-base-content placeholder:text-placeholder focus:outline-none",
+      data: {
+        post_form_toggle_target: "textarea textInput",
+        action: "input->post-form-toggle#autoResize keydown->post-form-toggle#submitOnEnter"
+      } %>
 <% end %>
 

--- a/app/views/posts/_text_post_form.html.erb
+++ b/app/views/posts/_text_post_form.html.erb
@@ -4,7 +4,7 @@
       autocomplete: "off",
       placeholder: placeholder_text.chomp,
       disabled: active_postable_type == "DocumentPost",
-      class: "textarea textarea-ghost w-full text-base-content placeholder:text-placeholder focus:outline-none",
+      class: "textarea textarea-ghost text-base w-full text-base-content placeholder:text-placeholder focus:outline-none",
       data: {
         post_form_toggle_target: "textarea textInput",
         action: "input->post-form-toggle#autoResize keydown->post-form-toggle#submitOnEnter"

--- a/app/views/posts/_text_post_form.html.erb
+++ b/app/views/posts/_text_post_form.html.erb
@@ -2,19 +2,16 @@
   <%= f.hidden_field :postable_type, value: "TextPost" %>
   
   <%= f.fields_for :postable_attributes, (post.postable.is_a?(TextPost) ? post.postable : TextPost.new) do |text_post_form| %>
-    <% placeholder_text = <<~TEXT
-      調べたことや思いついたことを書きましょう
-      コードスニペットは以下のように言語を指定して```で囲んで入力してください
-      ```ruby
-      puts "Hello, World!"
-      ```
-    TEXT
+    <% placeholder_text = "調べたことや思いついたことを書きましょう"
     %>
     <%= text_post_form.text_area :body,
         autocomplete: "off",
         placeholder: placeholder_text.chomp,
-        class: "textarea textarea-ghost w-full h-32 text-base-content placeholder:text-placeholder focus:outline-none",
-        data: { action: "keydown->post-form-toggle#submitOnEnter" } %>
+        class: "textarea textarea-ghost w-full text-base-content placeholder:text-placeholder focus:outline-none",
+        data: {
+          post_form_toggle_target: "textarea",
+          action: "input->post-form-toggle#autoResize keydown->post-form-toggle#submitOnEnter"
+        } %>
   <% end %>
   
   <div class="flex items-center justify-between gap-4 px-2">

--- a/spec/system/posts_spec.rb
+++ b/spec/system/posts_spec.rb
@@ -15,7 +15,7 @@ RSpec.describe 'Posts', type: :system do
       context '正常な入力の場合' do
         it 'TextPostが正常に作成される' do
           fill_in 'post[postable_attributes][body]', with: 'test text post'
-          within('#text-post-form') do
+          within('#post-form') do
             find('[data-test-id="submit-post-button"]').click
           end
 
@@ -36,7 +36,7 @@ RSpec.describe 'Posts', type: :system do
       context 'バリデーションエラーが発生する場合' do
         it 'bodyが空の場合、エラーメッセージが表示される' do
           fill_in 'post[postable_attributes][body]', with: ''
-          within('#text-post-form') do
+          within('#post-form') do
             find('[data-test-id="submit-post-button"]').click
           end
 
@@ -46,7 +46,7 @@ RSpec.describe 'Posts', type: :system do
 
         it 'bodyが1001文字以上の場合、エラーメッセージが表示される' do
           fill_in 'post[postable_attributes][body]', with: 'a' * 1001
-          within('#text-post-form') do
+          within('#post-form') do
             find('[data-test-id="submit-post-button"]').click
           end
 
@@ -59,7 +59,7 @@ RSpec.describe 'Posts', type: :system do
       context 'Markdown形式の入力の場合' do
         it '言語が指定されている場合、シンタックスハイライトが適用される' do
           fill_in 'post[postable_attributes][body]', with: "```ruby\ndef add(x,y)\n  x+y\nend\n```"
-          within('#text-post-form') do
+          within('#post-form') do
             find('[data-test-id="submit-post-button"]').click
           end
 
@@ -69,7 +69,7 @@ RSpec.describe 'Posts', type: :system do
 
         it '言語が指定されていない場合、シンタックスハイライトが適用されない' do
           fill_in 'post[postable_attributes][body]', with: "```\ndef add(x,y)\n  x+y\nend\n```"
-          within('#text-post-form') do
+          within('#post-form') do
             find('[data-test-id="submit-post-button"]').click
           end
 
@@ -82,7 +82,7 @@ RSpec.describe 'Posts', type: :system do
     context 'DocumentPost作成' do
       before do
         # DocumentPost投稿フォームへ切り替える
-        within('#text-post-form') do
+        within('#post-form') do
           find('label.toggle').click
         end
       end
@@ -90,7 +90,7 @@ RSpec.describe 'Posts', type: :system do
       context '正常な入力の場合' do
         it 'DocumentPostが正常に作成される' do
           fill_in 'post[postable_attributes][url]', with: 'https://docs.example.com'
-          within('#document-post-form') do
+          within('#post-form') do
             find('[data-test-id="submit-post-button"]').click
           end
 
@@ -103,7 +103,7 @@ RSpec.describe 'Posts', type: :system do
       context 'バリデーションエラーが発生する場合' do
         it 'urlが空の場合、エラーメッセージが表示される' do
           fill_in 'post[postable_attributes][url]', with: ''
-          within('#document-post-form') do
+          within('#post-form') do
             find('[data-test-id="submit-post-button"]').click
           end
 
@@ -113,7 +113,7 @@ RSpec.describe 'Posts', type: :system do
 
         it 'urlが無効な形式の場合、エラーメッセージが表示される' do
           fill_in 'post[postable_attributes][url]', with: 'あかさたな'
-          within('#document-post-form') do
+          within('#post-form') do
             find('[data-test-id="submit-post-button"]').click
           end
 
@@ -124,7 +124,7 @@ RSpec.describe 'Posts', type: :system do
 
         it 'urlがhttpまたはhttpsで始まらない場合、エラーメッセージが表示される' do
           fill_in 'post[postable_attributes][url]', with: 'ftp://example.com'
-          within('#document-post-form') do
+          within('#post-form') do
             find('[data-test-id="submit-post-button"]').click
           end
 

--- a/spec/system/posts_spec.rb
+++ b/spec/system/posts_spec.rb
@@ -15,13 +15,20 @@ RSpec.describe 'Posts', type: :system do
       context '正常な入力の場合' do
         it 'TextPostが正常に作成される' do
           fill_in 'post[postable_attributes][body]', with: 'test text post'
-          # text-post-formというidを持つformタグ内で送信ボタンをクリック
           within('#text-post-form') do
-            click_button '送信'
+            find('[data-test-id="submit-post-button"]').click
           end
 
           expect(page).to have_content('test text post')
           # expect(page).to have_content('コメントが投稿されました。')
+          expect(current_path).to eq task_path(task)
+        end
+
+        it 'EnterキーでTextPostが送信される' do
+          fill_in 'post[postable_attributes][body]', with: 'enter submit text post'
+          find('textarea[name="post[postable_attributes][body]"]').send_keys(:enter)
+
+          expect(page).to have_content('enter submit text post')
           expect(current_path).to eq task_path(task)
         end
       end
@@ -30,7 +37,7 @@ RSpec.describe 'Posts', type: :system do
         it 'bodyが空の場合、エラーメッセージが表示される' do
           fill_in 'post[postable_attributes][body]', with: ''
           within('#text-post-form') do
-            click_button '送信'
+            find('[data-test-id="submit-post-button"]').click
           end
 
           expect(page).to have_content('メモ を入力してください')
@@ -40,7 +47,7 @@ RSpec.describe 'Posts', type: :system do
         it 'bodyが1001文字以上の場合、エラーメッセージが表示される' do
           fill_in 'post[postable_attributes][body]', with: 'a' * 1001
           within('#text-post-form') do
-            click_button '送信'
+            find('[data-test-id="submit-post-button"]').click
           end
 
           expect(page).to have_content('メモ は1000文字以下で入力してください')
@@ -53,7 +60,7 @@ RSpec.describe 'Posts', type: :system do
         it '言語が指定されている場合、シンタックスハイライトが適用される' do
           fill_in 'post[postable_attributes][body]', with: "```ruby\ndef add(x,y)\n  x+y\nend\n```"
           within('#text-post-form') do
-            click_button '送信'
+            find('[data-test-id="submit-post-button"]').click
           end
 
           expect(page).to have_content('add(x,y)')
@@ -63,26 +70,28 @@ RSpec.describe 'Posts', type: :system do
         it '言語が指定されていない場合、シンタックスハイライトが適用されない' do
           fill_in 'post[postable_attributes][body]', with: "```\ndef add(x,y)\n  x+y\nend\n```"
           within('#text-post-form') do
-            click_button '送信'
+            find('[data-test-id="submit-post-button"]').click
           end
 
           expect(page).to have_content('add(x,y)')
-          expect(page).to have_selector('.highlight .plaintext')
+          expect(page).not_to have_selector('.highlight .ruby')
         end
       end
     end
 
     context 'DocumentPost作成' do
       before do
-        # DocumentPost投稿フォームのタブをクリック
-        find('input[aria-label="参照URL"]').click
+        # DocumentPost投稿フォームへ切り替える
+        within('#text-post-form') do
+          find('label.toggle').click
+        end
       end
 
       context '正常な入力の場合' do
         it 'DocumentPostが正常に作成される' do
           fill_in 'post[postable_attributes][url]', with: 'https://docs.example.com'
           within('#document-post-form') do
-            click_button '送信'
+            find('[data-test-id="submit-post-button"]').click
           end
 
           # ポスト一覧に投稿されたDocumentPostが表示されることを確認
@@ -95,7 +104,7 @@ RSpec.describe 'Posts', type: :system do
         it 'urlが空の場合、エラーメッセージが表示される' do
           fill_in 'post[postable_attributes][url]', with: ''
           within('#document-post-form') do
-            click_button '送信'
+            find('[data-test-id="submit-post-button"]').click
           end
 
           expect(page).to have_content('URL を入力してください')
@@ -105,7 +114,7 @@ RSpec.describe 'Posts', type: :system do
         it 'urlが無効な形式の場合、エラーメッセージが表示される' do
           fill_in 'post[postable_attributes][url]', with: 'あかさたな'
           within('#document-post-form') do
-            click_button '送信'
+            find('[data-test-id="submit-post-button"]').click
           end
 
           expect(page).to have_content('URL は無効な形式です')
@@ -116,7 +125,7 @@ RSpec.describe 'Posts', type: :system do
         it 'urlがhttpまたはhttpsで始まらない場合、エラーメッセージが表示される' do
           fill_in 'post[postable_attributes][url]', with: 'ftp://example.com'
           within('#document-post-form') do
-            click_button '送信'
+            find('[data-test-id="submit-post-button"]').click
           end
 
           expect(page).to have_content('URL はhttpまたはhttpsで始まる必要があります')


### PR DESCRIPTION
## 概要
タスク詳細画面のチャット投稿フォームを改善し、出力先切り替えUIをTabからdaisyUIのtoggleへ変更しました。あわせて送信ボタンのアイコン化、Enter送信対応、テキストエリアの自動リサイズ、トグルアニメーションが見える単一フォーム構成への整理、関連システムスペックの更新を実施しています。

### 関連するissue
- #440

## 主な変更点
- `app/views/posts/_form.html.erb`
  - Tabベースのフォーム切り替えを廃止し、Stimulus制御のtoggle切り替えに変更
  - TextPost / DocumentPost を単一フォーム内の入力パネルとして整理し、トグルと送信ボタンを1つに統一
- `app/javascript/controllers/post_form_toggle_controller.js`
  - TextPost / DocumentPost の表示切り替え
  - `postable_type` hidden field の同期
  - 非表示側入力の `disabled` 切り替え
  - テキストエリアの自動リサイズ
  - フォーム切り替え時の再リサイズ
  - TextPost / DocumentPost ともに Enter送信対応
- `app/views/posts/_text_post_form.html.erb`
  - TextPost入力欄専用パーシャルへ整理
  - 自動リサイズ対象と Enter送信イベントを付与
- `app/views/posts/_document_post_form.html.erb`
  - DocumentPost入力欄専用パーシャルへ整理
  - 自動リサイズ対象と Enter送信イベントを付与
- `app/helpers/application_helper.rb`
  - トグル内アイコン／送信アイコンのSVGヘルパーを追加
- `spec/system/posts_spec.rb`
  - 新UI（toggle・単一フォーム・アイコン送信）に合わせて操作を更新
  - Enter送信の検証を追加
  - Markdown未指定言語ケースの期待値を現行描画に合わせて調整

### UI
#### 変更前
<img width="2568" height="1064" alt="image" src="https://github.com/user-attachments/assets/2e1caff3-8c52-4177-899d-bd6b4c66e193"/>

#### 変更後
<img width="2568" height="935" alt="image" src="https://github.com/user-attachments/assets/d1b9f924-f49c-4520-9941-93bf49d506cb" />
