### PR TITLE
documentsテーブルにOGPカラムを追加し永続化する (#442)

### DIFF
--- a/app/models/document.rb
+++ b/app/models/document.rb
@@ -4,25 +4,35 @@ class Document < ApplicationRecord
   validates :url, presence: true, uniqueness: true
   validate :url_format_validation
 
-  # OGP情報を取得するメソッド
-  def ogp_info
-    @ogp_info ||= OgpScraperService.new(url).call
-  end
+  before_validation :fetch_ogp, on: :create
 
   # カード表示用のヘルパーメソッド
   def card_title
-    ogp_info[:title]
+    title.presence || "タイトルを取得できませんでした"
   end
 
   def card_description
-    ogp_info[:description]
+    description.presence || "説明文を取得できませんでした"
   end
 
   def card_image_url
-    ogp_info[:image_url]
+    image_url.presence
+  end
+
+  def card_has_image?
+    card_image_url.present?
   end
 
   private
+
+  def fetch_ogp
+    data = OgpScraperService.new(url).fetch_attributes
+    return if data.nil?
+
+    self.title = data[:title]
+    self.description = data[:description]
+    self.image_url = data[:image_url]
+  end
 
   def url_format_validation
     return if url.blank?

--- a/app/services/ogp_scraper_service.rb
+++ b/app/services/ogp_scraper_service.rb
@@ -7,16 +7,20 @@ class OgpScraperService
   end
 
   def call
+    fetch_attributes
+  end
+
+  # DBにOGP情報（title, description, image_url）を保存するためのメソッド
+  def fetch_attributes
     {
       title: extract_title,
       description: extract_description,
       image_url: extract_ogp_image
     }
-  # docの取得に失敗した場合、例外処理を実行
   rescue => e
     Rails.logger.error "以下のURLのOGP情報の取得に失敗しました: #{@url}\n
                         エラーメッセージ: #{e.message}"
-    fallback_data
+    nil
   end
 
   private
@@ -29,14 +33,14 @@ class OgpScraperService
     doc.at('meta[property="og:title"]')&.[]("content") ||
     doc.at("title")&.text&.strip ||
     doc.at("h1")&.text&.strip ||
-    @url
+    nil
   end
 
   def extract_description
     # OGP description > meta description
     doc.at('meta[property="og:description"]')&.[]("content") ||
     doc.at('meta[name="description"]')&.[]("content") ||
-    "不明"
+    nil
   end
 
   def extract_ogp_image
@@ -67,13 +71,5 @@ class OgpScraperService
       }
       Nokogiri::HTML(URI.open(@url, options))
     end
-  end
-
-  def fallback_data
-    {
-      title: @url,
-      description: "OGP情報の取得に失敗しました",
-      image_url: nil
-    }
   end
 end

--- a/app/views/posts/_document_card.html.erb
+++ b/app/views/posts/_document_card.html.erb
@@ -7,9 +7,9 @@
               class: "link link-info text-sm" %>
   
   <!-- メインコンテンツ -->
-  <div class="flex items-center gap-4">
+  <div class="flex justify-start items-center gap-2">
     <!-- 左側の緑色の縦線 -->
-    <div class="w-1 bg-green rounded-full self-stretch"></div>
+    <div class="flex-shrink-0 w-1 bg-green rounded-full self-stretch"></div>
 
     <!-- 中央のコンテンツ -->
     <div class="flex-1">
@@ -19,20 +19,18 @@
                     document.url, 
                     target: "_blank", 
                     rel: "noopener noreferrer",
-                    class: "text-base-content text-lg font-bold line-clamp-2 leading-tight" %>
+                    class: "text-base-content text-lg font-bold line-clamp-1 leading-tight" %>
         
         <!-- 説明文 -->
-        <% if document.card_description.present? %>
-          <p class="text-sm text-muted line-clamp-3 leading-relaxed">
-            <%= document.card_description %>
-          </p>
-        <% end %>
+        <p class="text-sm text-muted line-clamp-2 leading-relaxed">
+          <%= document.card_description %>
+        </p>
       </div>
     </div>
 
     <!-- 右側のアイコン -->
     <div class="flex-shrink-0">
-      <% if document.card_image_url.present? %>
+      <% if document.card_has_image? %>
         <%= image_tag document.card_image_url,
                       class: "w-12 h-12 object-cover rounded-lg" %>
       <% else %>

--- a/db/migrate/20260418130100_add_ogp_columns_to_documents.rb
+++ b/db/migrate/20260418130100_add_ogp_columns_to_documents.rb
@@ -1,0 +1,7 @@
+class AddOgpColumnsToDocuments < ActiveRecord::Migration[7.2]
+  def change
+    add_column :documents, :title, :string
+    add_column :documents, :description, :text
+    add_column :documents, :image_url, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.2].define(version: 2026_04_18_120000) do
+ActiveRecord::Schema[7.2].define(version: 2026_04_18_130100) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -25,6 +25,9 @@ ActiveRecord::Schema[7.2].define(version: 2026_04_18_120000) do
     t.string "url", null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.string "title"
+    t.text "description"
+    t.string "image_url"
     t.index ["url"], name: "index_documents_on_url", unique: true
   end
 

--- a/docs/operations.md
+++ b/docs/operations.md
@@ -1,0 +1,42 @@
+# rakeタスク運用メモ
+
+## documents:backfill_ogp
+
+### 目的
+
+`documents` テーブルに OGP 用カラム（`title` / `description` / `image_url`）を追加したマイグレーション適用後、**既存レコード**のこれらのカラムを外部サイトから取得して埋める。新規作成時はアプリ側で自動取得されるため、本タスクは**過去データの一度きりの移行**に相当する。
+
+### 実行タイミング
+
+- 該当マイグレーションを本番に適用した**直後**に、手動で 1 回実行する。
+- 開発環境では、マイグレーション後に必要に応じて実行する。
+
+### 開発環境での実行
+
+```zsh
+docker compose exec web bundle exec rails documents:backfill_ogp
+```
+
+### 本番環境（Render）での実行
+
+1. 実行前に **DB のバックアップ取得**を推奨する。
+2. Render ダッシュボード → 対象の Web Service → **Shell** タブを開く。
+3. 次を実行する。
+
+   ```zsh
+   bundle exec rails documents:backfill_ogp
+   ```
+
+4. 完了後、Rails コンソール等で成功状況を確認できる。
+
+   ```ruby
+   Document.where(title: nil).count
+   ```
+
+   `title` が取得できなかったレコードは `nil` のまま残る。表示は `card_title` の URL フォールバックで破綻しない。
+
+### 挙動
+
+- 対象は **`title` が `nil` の `Document` のみ**（何度実行しても同じ結果になりやすい冪等な範囲）。
+- 外部サイトへの負荷を避けるため、レコード間に短い待機を挟む。
+- 1 件で失敗してもタスク全体は継続し、ログに記録する。

--- a/lib/tasks/documents.rake
+++ b/lib/tasks/documents.rake
@@ -1,0 +1,30 @@
+namespace :documents do
+  desc "既存DocumentのOGPカラム（title/description/image_url）をバックフィルする（title または description が nil のレコードが対象・冪等）"
+  task backfill_ogp: :environment do
+    scope = Document.where(title: nil).or(Document.where(description: nil))
+    total = scope.count
+    processed = 0
+
+    scope.find_each do |document|
+      processed += 1
+      begin
+        data = OgpScraperService.new(document.url).fetch_attributes
+        if data
+          document.update_columns(
+            title: data[:title],
+            description: data[:description],
+            image_url: data[:image_url],
+            updated_at: Time.current
+          )
+        end
+      rescue => e
+        Rails.logger.error(
+          "[documents:backfill_ogp] [#{processed}/#{total}] id=#{document.id} url=#{document.url} error=#{e.class}: #{e.message}"
+        )
+      end
+
+      puts "[documents:backfill_ogp] [#{processed}/#{total}] id=#{document.id}"
+      sleep 0.5
+    end
+  end
+end

--- a/spec/models/document_spec.rb
+++ b/spec/models/document_spec.rb
@@ -79,4 +79,38 @@ RSpec.describe Document, type: :model do
       end
     end
   end
+
+  describe 'DocumentのOGP情報の保存' do
+    let(:url) { 'https://ogp.example.com/page' }
+
+    context 'OGP取得成功時' do
+      before do
+        allow_any_instance_of(OgpScraperService).to receive(:fetch_attributes).and_return(
+          title: 'OGPタイトル',
+          description: 'OGP説明',
+          image_url: 'https://ogp.example.com/og.png'
+        )
+      end
+
+      it 'Documentは作成され、title / description / image_url に値が保存される' do
+        document = described_class.create!(url: url)
+        expect(document.title).to eq('OGPタイトル')
+        expect(document.description).to eq('OGP説明')
+        expect(document.image_url).to eq('https://ogp.example.com/og.png')
+      end
+    end
+
+    context 'OGP取得失敗時' do
+      before do
+        allow_any_instance_of(OgpScraperService).to receive(:fetch_attributes).and_return(nil)
+      end
+
+      it 'Documentは作成され、title / description / image_url にnilが保存される' do
+        document = described_class.create!(url: url)
+        expect(document.title).to be_nil
+        expect(document.description).to be_nil
+        expect(document.image_url).to be_nil
+      end
+    end
+  end
 end


### PR DESCRIPTION
## 概要

`documents` に `title` / `description` / `image_url` を追加し、新規作成時に `OgpScraperService#fetch_attributes` で取得して DB に保存します。リッチカード表示はこれらのカラムを参照するようにし、既存レコード向けに `documents:backfill_ogp` と運用手順を追加しました。

### 関連するissue

Closes #442

## 主な変更点

- マイグレーションで `documents` に OGP 用カラムを追加
- `Document` に `before_validation :fetch_ogp, on: :create` を追加し、`card_title` / `card_description` / `card_image_url`（および `card_has_image?`）をカラム参照に変更
- `OgpScraperService` に永続化用の `fetch_attributes`（取得失敗時は `nil`）を定義。`call` は `fetch_attributes` を返す形に整理
- 冪等な rake タスク `documents:backfill_ogp` と `docs/operations.md`（開発・本番の実行手順）
- `Document` のモデルスペックを更新（成功時の保存・失敗時の nil 保存）

## 追加実装の予定

Issue 記載のスコープ外（タスク内ドキュメント一覧・情報更新ボタン・TIL 雛形など）は別 Issue で対応予定です。
